### PR TITLE
Fixed: ParseUser.getCurrentUser() returns a non authenticated user when local datastore is used

### DIFF
--- a/Parse/src/main/java/com/parse/ParseUser.java
+++ b/Parse/src/main/java/com/parse/ParseUser.java
@@ -501,6 +501,16 @@ public class ParseUser extends ParseObject {
   }
 
   @Override
+  /* package */ void setState(ParseObject.State newState) {
+    // Avoid clearing sessionToken when updating the current user's State via ParseQuery result
+    if (isCurrentUser() && getSessionToken() != null
+            && newState.get("sessionToken") == null) {
+      newState = newState.newBuilder().put("sessionToken", getSessionToken()).build();
+    }
+    super.setState(newState);
+  }
+
+  @Override
   /* package */ void validateDelete() {
     synchronized (mutex) {
       super.validateDelete();

--- a/Parse/src/test/java/com/parse/ParseUserTest.java
+++ b/Parse/src/test/java/com/parse/ParseUserTest.java
@@ -1059,6 +1059,41 @@ public class ParseUserTest {
     verify(currentUserController, times(1)).setAsync(user);
   }
 
+  @Test
+  public void testDontOverwriteSessionTokenForCurrentUser() throws Exception {
+    ParseUser.State sessionTokenState = new ParseUser.State.Builder()
+            .sessionToken("sessionToken")
+            .put("key0", "value0")
+            .put("key1", "value1")
+            .isComplete(true)
+            .build();
+    ParseUser.State newState = new ParseUser.State.Builder()
+            .put("key0", "newValue0")
+            .put("key2", "value2")
+            .isComplete(true)
+            .build();
+    ParseUser.State emptyState = new ParseUser.State.Builder().isComplete(true).build();
+
+    ParseUser user = ParseObject.from(sessionTokenState);
+    user.setIsCurrentUser(true);
+    assertEquals(user.getSessionToken(), "sessionToken");
+    assertEquals(user.getString("key0"), "value0");
+    assertEquals(user.getString("key1"), "value1");
+
+    user.setState(newState);
+    assertEquals(user.getSessionToken(), "sessionToken");
+    assertEquals(user.getString("key0"), "newValue0");
+    assertNull(user.getString("key1"));
+    assertEquals(user.getString("key2"), "value2");
+
+    user.setIsCurrentUser(false);
+    user.setState(emptyState);
+    assertNull(user.getSessionToken());
+    assertNull(user.getString("key0"));
+    assertNull(user.getString("key1"));
+    assertNull(user.getString("key2"));
+  }
+
   //endregion
 
   //region testUnlinkFromAsync


### PR DESCRIPTION
Repro project: https://www.dropbox.com/s/m6vl215mg3nj8uo/Parse-Starter-Project-1.9.4.zip
1- change keys
2- click SIGN UP
-> make sure a user & a post are created
3- click GETCURRENTUSER
-> make sure user and session are shown
4- click ISAUTHENTICATED()
-> make sure it returns true
5- now click QUERY DATA WITH INCLUDE("USER")
6- repeat step 3 and 4 and notice the issue