### PR TITLE
Fix: Unable to receive null response from Cloud Code

### DIFF
--- a/Parse/src/main/java/com/parse/ParseCloud.java
+++ b/Parse/src/main/java/com/parse/ParseCloud.java
@@ -11,9 +11,6 @@ package com.parse;
 import java.util.List;
 import java.util.Map;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import bolts.Continuation;
 import bolts.Task;
 

--- a/Parse/src/main/java/com/parse/ParseCloudCodeController.java
+++ b/Parse/src/main/java/com/parse/ParseCloudCodeController.java
@@ -8,7 +8,6 @@
  */
 package com.parse;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.Map;
@@ -46,11 +45,7 @@ import bolts.Task;
   /* package for test */ Object convertCloudResponse(Object result) {
     if (result instanceof JSONObject) {
       JSONObject jsonResult = (JSONObject)result;
-      try {
-        result = jsonResult.get("result");
-      } catch (JSONException e) {
-        return result;
-      }
+      result = jsonResult.opt("result");
     }
 
     ParseDecoder decoder = ParseDecoder.get();

--- a/Parse/src/test/java/com/parse/ParseCloudCodeControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParseCloudCodeControllerTest.java
@@ -11,7 +11,6 @@ package com.parse;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -31,7 +30,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 public class ParseCloudCodeControllerTest {
 
@@ -57,21 +55,6 @@ public class ParseCloudCodeControllerTest {
     Object result = controller.convertCloudResponse(null);
 
     assertNull(result);
-  }
-
-  @Test
-  public void testConvertCloudResponseJsonResponseWithoutResultField() throws Exception {
-    ParseHttpClient restClient = mock(ParseHttpClient.class);
-    ParseCloudCodeController controller = new ParseCloudCodeController(restClient);
-    JSONObject response = new JSONObject();
-    response.put("foo", "bar");
-    response.put("yarr", 1);
-
-    Object result = controller.convertCloudResponse(response);
-
-    assertThat(result, instanceOf(JSONObject.class));
-    JSONObject jsonResult = (JSONObject)result;
-    assertEquals(response, jsonResult, JSONCompareMode.NON_EXTENSIBLE);
   }
 
   @Test

--- a/Parse/src/test/java/com/parse/ParseCloudCodeControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParseCloudCodeControllerTest.java
@@ -116,7 +116,7 @@ public class ParseCloudCodeControllerTest {
   }
 
   @Test
-  public void testCallFunctionInBackgroundSuccess() throws Exception {
+  public void testCallFunctionInBackgroundSuccessWithResult() throws Exception {
     JSONObject json = new JSONObject();
     json.put("result", "test");
     String content = json.toString();
@@ -135,6 +135,27 @@ public class ParseCloudCodeControllerTest {
 
     verify(restClient, times(1)).execute(any(ParseHttpRequest.class));
     assertEquals("test", cloudCodeTask.getResult());
+  }
+
+  @Test
+  public void testCallFunctionInBackgroundSuccessWithoutResult() throws Exception {
+    JSONObject json = new JSONObject();
+    String content = json.toString();
+
+    ParseHttpResponse mockResponse = mock(ParseHttpResponse.class);
+    when(mockResponse.getStatusCode()).thenReturn(200);
+    when(mockResponse.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes()));
+    when(mockResponse.getTotalSize()).thenReturn(content.length());
+
+    ParseHttpClient restClient = mockParseHttpClientWithReponse(mockResponse);
+    ParseCloudCodeController controller = new ParseCloudCodeController(restClient);
+
+    Task<String> cloudCodeTask = controller.callFunctionInBackground(
+        "test", new HashMap<String, Object>(), "sessionToken");
+    ParseTaskUtils.wait(cloudCodeTask);
+
+    verify(restClient, times(1)).execute(any(ParseHttpRequest.class));
+    assertNull(cloudCodeTask.getResult());
   }
 
   @Test


### PR DESCRIPTION
`res.success(null)` from Cloud Code caused `ParseCloud.callFunctionInBackground()` to return a `JSONObject`, which would result in `ClassCastException` in developer code since they would normally expect a `String` or something.

This change fixes that.

/cc @hallucinogen @wangmengyan95 @nlutsenko