### PR TITLE
Update ParseLogInterceptor to handle gzip stream

### DIFF
--- a/Parse/src/main/java/com/parse/ParseHttpRequest.java
+++ b/Parse/src/main/java/com/parse/ParseHttpRequest.java
@@ -8,6 +8,7 @@
  */
 package com.parse;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -21,7 +22,7 @@ import java.util.Map;
   protected ParseHttpRequest(Builder builder) {
     this.url = builder.url;
     this.method = builder.method;
-    this.headers = builder.headers;
+    this.headers = Collections.unmodifiableMap(new HashMap<>(builder.headers));
     this.body = builder.body;
   }
 
@@ -59,8 +60,6 @@ import java.util.Map;
       this.url = request.url;
       this.method = request.method;
       this.headers = new HashMap<>(request.headers);
-      // TODO(mengyan) This direct copy make ParseHttpRequest not truly immutable.
-      // We need to 'clone' a ParseHttpBody here.
       this.body = request.body;
     }
 

--- a/Parse/src/main/java/com/parse/ParseHttpResponse.java
+++ b/Parse/src/main/java/com/parse/ParseHttpResponse.java
@@ -29,6 +29,10 @@ import java.util.Map;
 
     /* package */ abstract T self();
 
+    public Init() {
+      this.headers = new HashMap<>();
+    }
+
     public T setStatusCode(int statusCode) {
       this.statusCode = statusCode;
       return self();
@@ -50,7 +54,17 @@ import java.util.Map;
     }
 
     public T setHeaders(Map<String, String> headers) {
-      this.headers = Collections.unmodifiableMap(new HashMap<>(headers));
+      this.headers = new HashMap<>(headers);
+      return self();
+    }
+
+    public T addHeaders(Map<String, String> headers) {
+      this.headers.putAll(headers);
+      return self();
+    }
+
+    public T addHeader(String key, String value) {
+      this.headers.put(key, value);
       return self();
     }
 
@@ -84,7 +98,7 @@ import java.util.Map;
     this.content = builder.content;
     this.totalSize = builder.totalSize;
     this.reasonPhrase = builder.reasonPhrase;
-    this.headers = builder.headers;
+    this.headers = Collections.unmodifiableMap(new HashMap<>(builder.headers));
     this.contentType = builder.contentType;
   }
 

--- a/Parse/src/test/java/com/parse/OfflineObjectStoreTest.java
+++ b/Parse/src/test/java/com/parse/OfflineObjectStoreTest.java
@@ -260,3 +260,4 @@ public class OfflineObjectStoreTest {
 
   //endregion
 }
+

--- a/Parse/src/test/java/com/parse/ParseHttpResponseTest.java
+++ b/Parse/src/test/java/com/parse/ParseHttpResponseTest.java
@@ -31,7 +31,7 @@ public class ParseHttpResponseTest {
     assertNull(response.getReasonPhrase());
     assertEquals(0, response.getStatusCode());
     assertEquals(0, response.getTotalSize());
-    assertNull(response.getAllHeaders());
+    assertEquals(0, response.getAllHeaders().size());
     assertNull(response.getHeader("test"));
   }
 

--- a/Parse/src/test/java/com/parse/ParseLogInterceptorTest.java
+++ b/Parse/src/test/java/com/parse/ParseLogInterceptorTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+package com.parse;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+// For GZIPOutputStream
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21)
+public class ParseLogInterceptorTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testInterceptNotGZIPResponse() throws Exception {
+    ParseLogInterceptor interceptor = new ParseLogInterceptor();
+
+    final String content = "content";
+    final Semaphore done = new Semaphore(0);
+    interceptor.setLogger(new ParseLogInterceptor.Logger() {
+      @Override
+      public void write(String str) {
+      }
+
+      @Override
+      public void writeLine(String name, String value) {
+       if ("Body".equals(name)) {
+          assertEquals(content, value);
+          done.release();
+       }
+      }
+    });
+
+    ParseHttpResponse response = interceptor.intercept(new ParseNetworkInterceptor.Chain() {
+      @Override
+      public ParseHttpRequest getRequest() {
+        // We do not need request for this test so we simply return an empty request
+        return new ParseHttpRequest.Builder().setMethod(ParseRequest.Method.GET).build();
+      }
+
+      @Override
+      public ParseHttpResponse proceed(ParseHttpRequest request) throws IOException {
+        ParseHttpResponse response = new ParseHttpResponse.Builder()
+            .setContentType("application/json")
+            .setContent(new ByteArrayInputStream(content.getBytes()))
+            .build();
+        return response;
+      }
+    });
+
+    // Make sure the content we get from response is correct
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    ParseIOUtils.copy(response.getContent(), output);
+    assertEquals(content, new String(output.toByteArray()));
+    // Make sure we log the right content
+    assertTrue(done.tryAcquire(10, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void testInterceptGZIPResponse() throws Exception {
+    ParseLogInterceptor interceptor = new ParseLogInterceptor();
+
+    final String content = "content";
+    final ByteArrayOutputStream gzipByteOutput = new ByteArrayOutputStream();
+    GZIPOutputStream gzipOutput = new GZIPOutputStream(gzipByteOutput);
+    gzipOutput.write(content.getBytes());
+    gzipOutput.close();
+
+    final Semaphore done = new Semaphore(0);
+    interceptor.setLogger(new ParseLogInterceptor.Logger() {
+      @Override
+      public void write(String str) {
+      }
+
+      @Override
+      public void writeLine(String name, String value) {
+       if ("Body".equals(name)) {
+          assertEquals(content, value);
+          done.release();
+       }
+      }
+    });
+
+    ParseHttpResponse response = interceptor.intercept(new ParseNetworkInterceptor.Chain() {
+      @Override
+      public ParseHttpRequest getRequest() {
+        // We do not need request for this test so we simply return an empty request
+        return new ParseHttpRequest.Builder().setMethod(ParseRequest.Method.GET).build();
+      }
+
+      @Override
+      public ParseHttpResponse proceed(ParseHttpRequest request) throws IOException {
+        ParseHttpResponse response = new ParseHttpResponse.Builder()
+            .addHeader("Content-Encoding", "gzip")
+            .setContentType("application/json")
+            .setContent(new ByteArrayInputStream(gzipByteOutput.toByteArray()))
+            .build();
+        return response;
+      }
+    });
+
+    // Make sure the content we get from response is the gzip content
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    ParseIOUtils.copy(response.getContent(), output);
+    assertArrayEquals(gzipByteOutput.toByteArray(), output.toByteArray());
+    // Make sure we log the ungzip content
+    assertTrue(done.tryAcquire(10, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void testInterceptResponseWithException() throws Exception {
+    ParseLogInterceptor interceptor = new ParseLogInterceptor();
+
+    final String errorMessage = "error";
+    final Semaphore done = new Semaphore(0);
+    interceptor.setLogger(new ParseLogInterceptor.Logger() {
+      @Override
+      public void write(String str) {
+      }
+
+      @Override
+      public void writeLine(String name, String value) {
+       if ("Error".equals(name)) {
+          assertEquals(errorMessage, value);
+          done.release();
+       }
+      }
+    });
+
+    // Make sure the exception we get is correct
+    thrown.expect(IOException.class);
+    thrown.expectMessage(errorMessage);
+
+    interceptor.intercept(new ParseNetworkInterceptor.Chain() {
+      @Override
+      public ParseHttpRequest getRequest() {
+        // We do not need request for this test so we simply return an empty request
+        return new ParseHttpRequest.Builder().setMethod(ParseRequest.Method.GET).build();
+      }
+
+      @Override
+      public ParseHttpResponse proceed(ParseHttpRequest request) throws IOException {
+        throw new IOException(errorMessage);
+      }
+    });
+
+    // Make sure we log the right content
+    assertTrue(done.tryAcquire(10, TimeUnit.SECONDS));
+  }
+}


### PR DESCRIPTION
1. Update ParseLogInterceptor to handle GZIP response body stream
2. Decouple ProxyInputStream (Split the proxy logic and log response logic)
3. Clean ParseHttpRequest and ParseHttpResponse
4. Add test