### PR TITLE
Disable ApacheHttpClient auto retry in order to expose real exception to interceptor

### DIFF
--- a/Parse/src/main/java/com/parse/ParseApacheHttpClient.java
+++ b/Parse/src/main/java/com/parse/ParseApacheHttpClient.java
@@ -31,6 +31,7 @@ import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
@@ -91,6 +92,14 @@ import java.util.Map;
 
     ClientConnectionManager manager = new ThreadSafeClientConnManager(params, schemeRegistry);
     apacheClient = new DefaultHttpClient(manager, params);
+
+    // Disable retry logic by ApacheHttpClient. When we leave the app idle for 3 - 5 min, the next
+    // request will always fail with NoHttpResponseException: The target server failed to respond,
+    // in this situation, the Apache httpClient will try to retry the request,
+    // however, since we use InputStreamEntity which is non-repeatable, we will see the
+    // NonRepeatableRequestException: Cannot retry request with a non-repeatable request entity.
+    // We disable the retry logic by ApacheHttpClient to expose the real issue
+    apacheClient.setHttpRequestRetryHandler(new DefaultHttpRequestRetryHandler(0, false));
   }
 
   @Override

--- a/Parse/src/main/java/com/parse/ParseRequest.java
+++ b/Parse/src/main/java/com/parse/ParseRequest.java
@@ -10,8 +10,6 @@ package com.parse;
 
 import android.os.Build;
 
-import org.apache.http.client.ClientProtocolException;
-
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -200,9 +198,7 @@ import bolts.Task;
       public Task<Response> then(Task<Response> task) throws Exception {
         if (task.isFaulted()) {
           Exception error = task.getError();
-          if (error instanceof ClientProtocolException) {
-            return Task.forError(newTemporaryException("bad protocol", error));
-          } else if (error instanceof IOException) {
+          if (error instanceof IOException) {
             return Task.forError(newTemporaryException("i/o failure", error));
           }
         }


### PR DESCRIPTION
1. When we use Apache httpClient and leave the app idle for 3 - 5 min, the next request will always fail with `org.apache.http.NoHttpResponseException: The target server failed to respond`, in this situation, the Apache httpClient will try to retry the request, however, since we use `InputStreamEntity` which is non-repeatable, we will see the `org.apache.http.client.NonRepeatableRequestException: Cannot retry request with a non-repeatable request entity` thrown by Apache httpclient execute method.
2. After we get this exception, the following requests will be executed fine.
3. I try to use a external proxy(Charles) to observe the communication, what I find is the proxy can always get the response successfully.
4. In order to expose the real exception to interceptors, we disable the Apache httpClient auto retry. It seems we have found this phenomenon long time ago, since in our codebase, we handle `ClientProtocolException` in `ParseRequest`. https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/ParseRequest.java#L203. Since this will not happen anymore, I will also delete this logic.
5. We do not use `BufferedHttpEntity` because for file upload request, it is too expensive to buffer to whole request.
