### PR TITLE
Remove isLazy property in ParseUser

### DIFF
--- a/Parse/src/main/java/com/parse/CachedCurrentUserController.java
+++ b/Parse/src/main/java/com/parse/CachedCurrentUserController.java
@@ -241,8 +241,6 @@ import bolts.Task;
                 if (current != null) {
                   synchronized (current.mutex) {
                     current.setIsCurrentUser(true);
-                    current.isLazy = current.getObjectId() == null
-                        && ParseAnonymousUtils.isLinked(current);
                   }
                   return current;
                 }
@@ -267,10 +265,10 @@ import bolts.Task;
   }
 
   /* package for tests */ ParseUser lazyLogIn(String authType, Map<String, String> authData) {
+    // Note: if authType != ParseAnonymousUtils.AUTH_TYPE the user is not "lazy".
     ParseUser user = ParseObject.create(ParseUser.class);
     synchronized (user.mutex) {
       user.setIsCurrentUser(true);
-      user.isLazy = true;
       user.putAuthData(authType, authData);
     }
 

--- a/Parse/src/main/java/com/parse/ParseUser.java
+++ b/Parse/src/main/java/com/parse/ParseUser.java
@@ -149,8 +149,6 @@ public class ParseUser extends ParseObject {
     }
   }
 
-  /* package */ boolean isLazy;
-
   // Whether the object is a currentUser. If so, it will always be persisted to disk on updates.
   private boolean isCurrentUser;
 
@@ -159,7 +157,6 @@ public class ParseUser extends ParseObject {
    * have an objectId and will not persist to the database until {@link #signUp} is called.
    */
   public ParseUser() {
-    isLazy = false;
     isCurrentUser = false;
   }
 
@@ -190,7 +187,7 @@ public class ParseUser extends ParseObject {
    */
   /* package */ boolean isLazy() {
     synchronized (mutex) {
-      return isLazy;
+      return getObjectId() == null && ParseAnonymousUtils.isLinked(this);
     }
   }
 
@@ -673,9 +670,6 @@ public class ParseUser extends ParseObject {
                 @Override
                 public Task<Void> then(Task<Void> task) throws Exception {
                   if (!signUpTask.isCancelled() && !signUpTask.isFaulted()) {
-                    synchronized (mutex) {
-                      isLazy = false;
-                    }
                     return saveCurrentUserAsync(ParseUser.this);
                   }
                   return signUpTask.makeVoid();
@@ -1302,7 +1296,6 @@ public class ParseUser extends ParseObject {
           @Override
           public ParseUser then(Task<Void> task) throws Exception {
             synchronized (mutex) {
-              isLazy = false;
               return ParseUser.this;
             }
           }
@@ -1347,12 +1340,6 @@ public class ParseUser extends ParseObject {
                         return newUser;
                       }
                     });
-                  }
-
-                  // Otherwise, merge it into the current user.
-                  // This is in Android, but not iOS because iOS has handleSignUpOrLogInResult.
-                  synchronized (mutex) {
-                    isLazy = false;
                   }
                   return Task.forResult(ParseUser.this);
                 }

--- a/Parse/src/test/java/com/parse/CachedCurrentUserControllerTest.java
+++ b/Parse/src/test/java/com/parse/CachedCurrentUserControllerTest.java
@@ -331,7 +331,7 @@ public class CachedCurrentUserControllerTest {
     CachedCurrentUserController controller =
         new CachedCurrentUserController(null);
 
-    String authType = "test";
+    String authType = ParseAnonymousUtils.AUTH_TYPE;
     Map<String, String> authData = new HashMap<>();
     authData.put("sessionToken", "testSessionToken");
 
@@ -342,7 +342,7 @@ public class CachedCurrentUserControllerTest {
     assertTrue(user.isCurrentUser());
     Map<String, Map<String, String>> authPair = user.getMap(KEY_AUTH_DATA);
     assertEquals(1, authPair.size());
-    Map<String, String> authDataAgain = authPair.get("test");
+    Map<String, String> authDataAgain = authPair.get(authType);
     assertEquals(1, authDataAgain.size());
     assertEquals("testSessionToken", authDataAgain.get("sessionToken"));
     // Make sure controller state is correct

--- a/Parse/src/test/java/com/parse/ParseACLTest.java
+++ b/Parse/src/test/java/com/parse/ParseACLTest.java
@@ -18,6 +18,9 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -141,7 +144,7 @@ public class ParseACLTest {
     ParseACL acl = new ParseACL();
     acl.setReadAccess("userId", true);
     ParseUser unresolvedUser = new ParseUser();
-    unresolvedUser.isLazy = true;
+    setLazy(unresolvedUser);
     acl.setReadAccess(unresolvedUser, true);
     // Mock decoder
     ParseEncoder mockEncoder = mock(ParseEncoder.class);
@@ -188,7 +191,7 @@ public class ParseACLTest {
   @Test
   public void testResolveUserWithNewUser() throws Exception {
     ParseUser unresolvedUser = new ParseUser();
-    unresolvedUser.isLazy = true;
+    setLazy(unresolvedUser);
     ParseACL acl = new ParseACL();
     acl.setReadAccess(unresolvedUser, true);
 
@@ -202,7 +205,7 @@ public class ParseACLTest {
   public void testResolveUserWithUnresolvedUser() throws Exception {
     ParseACL acl = new ParseACL();
     ParseUser unresolvedUser = new ParseUser();
-    unresolvedUser.isLazy = true;
+    setLazy(unresolvedUser);
     // This will set the unresolvedUser in acl
     acl.setReadAccess(unresolvedUser, true);
     acl.setWriteAccess(unresolvedUser, true);
@@ -211,8 +214,8 @@ public class ParseACLTest {
     acl.resolveUser(unresolvedUser);
 
     assertNull(acl.getUnresolvedUser());
-    assertFalse(acl.getReadAccess(unresolvedUser));
-    assertFalse(acl.getWriteAccess(unresolvedUser));
+    assertTrue(acl.getReadAccess(unresolvedUser));
+    assertTrue(acl.getWriteAccess(unresolvedUser));
     assertEquals(1, acl.getPermissionsById().length());
     assertFalse(acl.getPermissionsById().has(UNRESOLVED_KEY));
   }
@@ -525,7 +528,7 @@ public class ParseACLTest {
   public void testGetUserReadAccessWithUnresolvedUser() throws Exception {
     ParseACL acl = new ParseACL();
     ParseUser user = new ParseUser();
-    user.isLazy = true;
+    setLazy(user);
     // Since user is a lazy user, this will set the acl's unresolved user and give it read access
     acl.setReadAccess(user ,true);
 
@@ -536,7 +539,7 @@ public class ParseACLTest {
   public void testGetUserReadAccessWithLazyUser() throws Exception {
     ParseACL acl = new ParseACL();
     ParseUser user = new ParseUser();
-    user.isLazy = true;
+    setLazy(user);
 
     assertFalse(acl.getReadAccess(user));
   }
@@ -563,7 +566,7 @@ public class ParseACLTest {
   public void testGetUserWriteAccessWithUnresolvedUser() throws Exception {
     ParseACL acl = new ParseACL();
     ParseUser user = new ParseUser();
-    user.isLazy = true;
+    setLazy(user);
     // Since user is a lazy user, this will set the acl's unresolved user and give it write access
     acl.setWriteAccess(user, true);
 
@@ -613,7 +616,7 @@ public class ParseACLTest {
   public void testUnresolvedUser() throws Exception {
     ParseACL acl = new ParseACL();
     ParseUser user = new ParseUser();
-    user.isLazy = true;
+    setLazy(user);
     // This will set unresolvedUser in acl
     acl.setReadAccess(user, true);
 
@@ -622,4 +625,10 @@ public class ParseACLTest {
   }
 
   //endregion
+
+  private static void setLazy(ParseUser user) {
+    Map<String, String> anonymousAuthData = new HashMap<>();
+    anonymousAuthData.put("anonymousToken", "anonymousTest");
+    user.putAuthData(ParseAnonymousUtils.AUTH_TYPE, anonymousAuthData);
+  }
 }


### PR DESCRIPTION
We always have the invariant:
```lazy == true``` <==> ```objectId == null && authData.get("anonymous") != null```

So we can remove the additional property.

For testing: to get the "lazy" user behavior we need to make sure that the user has no ```objectId``` and we need to set "anonymous" ```authData``` (see ```setLazy()``` in ```ParseACLTest.java```).