### PR TITLE
Revert "Remove isLazy property in ParseUser"

### DIFF
--- a/Parse/src/main/java/com/parse/CachedCurrentUserController.java
+++ b/Parse/src/main/java/com/parse/CachedCurrentUserController.java
@@ -241,6 +241,8 @@ import bolts.Task;
                 if (current != null) {
                   synchronized (current.mutex) {
                     current.setIsCurrentUser(true);
+                    current.isLazy = current.getObjectId() == null
+                        && ParseAnonymousUtils.isLinked(current);
                   }
                   return current;
                 }
@@ -265,10 +267,10 @@ import bolts.Task;
   }
 
   /* package for tests */ ParseUser lazyLogIn(String authType, Map<String, String> authData) {
-    // Note: if authType != ParseAnonymousUtils.AUTH_TYPE the user is not "lazy".
     ParseUser user = ParseObject.create(ParseUser.class);
     synchronized (user.mutex) {
       user.setIsCurrentUser(true);
+      user.isLazy = true;
       user.putAuthData(authType, authData);
     }
 

--- a/Parse/src/test/java/com/parse/CachedCurrentUserControllerTest.java
+++ b/Parse/src/test/java/com/parse/CachedCurrentUserControllerTest.java
@@ -331,7 +331,7 @@ public class CachedCurrentUserControllerTest {
     CachedCurrentUserController controller =
         new CachedCurrentUserController(null);
 
-    String authType = ParseAnonymousUtils.AUTH_TYPE;
+    String authType = "test";
     Map<String, String> authData = new HashMap<>();
     authData.put("sessionToken", "testSessionToken");
 
@@ -342,7 +342,7 @@ public class CachedCurrentUserControllerTest {
     assertTrue(user.isCurrentUser());
     Map<String, Map<String, String>> authPair = user.getMap(KEY_AUTH_DATA);
     assertEquals(1, authPair.size());
-    Map<String, String> authDataAgain = authPair.get(authType);
+    Map<String, String> authDataAgain = authPair.get("test");
     assertEquals(1, authDataAgain.size());
     assertEquals("testSessionToken", authDataAgain.get("sessionToken"));
     // Make sure controller state is correct

--- a/Parse/src/test/java/com/parse/ParseACLTest.java
+++ b/Parse/src/test/java/com/parse/ParseACLTest.java
@@ -18,9 +18,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -144,7 +141,7 @@ public class ParseACLTest {
     ParseACL acl = new ParseACL();
     acl.setReadAccess("userId", true);
     ParseUser unresolvedUser = new ParseUser();
-    setLazy(unresolvedUser);
+    unresolvedUser.isLazy = true;
     acl.setReadAccess(unresolvedUser, true);
     // Mock decoder
     ParseEncoder mockEncoder = mock(ParseEncoder.class);
@@ -191,7 +188,7 @@ public class ParseACLTest {
   @Test
   public void testResolveUserWithNewUser() throws Exception {
     ParseUser unresolvedUser = new ParseUser();
-    setLazy(unresolvedUser);
+    unresolvedUser.isLazy = true;
     ParseACL acl = new ParseACL();
     acl.setReadAccess(unresolvedUser, true);
 
@@ -205,7 +202,7 @@ public class ParseACLTest {
   public void testResolveUserWithUnresolvedUser() throws Exception {
     ParseACL acl = new ParseACL();
     ParseUser unresolvedUser = new ParseUser();
-    setLazy(unresolvedUser);
+    unresolvedUser.isLazy = true;
     // This will set the unresolvedUser in acl
     acl.setReadAccess(unresolvedUser, true);
     acl.setWriteAccess(unresolvedUser, true);
@@ -214,8 +211,8 @@ public class ParseACLTest {
     acl.resolveUser(unresolvedUser);
 
     assertNull(acl.getUnresolvedUser());
-    assertTrue(acl.getReadAccess(unresolvedUser));
-    assertTrue(acl.getWriteAccess(unresolvedUser));
+    assertFalse(acl.getReadAccess(unresolvedUser));
+    assertFalse(acl.getWriteAccess(unresolvedUser));
     assertEquals(1, acl.getPermissionsById().length());
     assertFalse(acl.getPermissionsById().has(UNRESOLVED_KEY));
   }
@@ -528,7 +525,7 @@ public class ParseACLTest {
   public void testGetUserReadAccessWithUnresolvedUser() throws Exception {
     ParseACL acl = new ParseACL();
     ParseUser user = new ParseUser();
-    setLazy(user);
+    user.isLazy = true;
     // Since user is a lazy user, this will set the acl's unresolved user and give it read access
     acl.setReadAccess(user ,true);
 
@@ -539,7 +536,7 @@ public class ParseACLTest {
   public void testGetUserReadAccessWithLazyUser() throws Exception {
     ParseACL acl = new ParseACL();
     ParseUser user = new ParseUser();
-    setLazy(user);
+    user.isLazy = true;
 
     assertFalse(acl.getReadAccess(user));
   }
@@ -566,7 +563,7 @@ public class ParseACLTest {
   public void testGetUserWriteAccessWithUnresolvedUser() throws Exception {
     ParseACL acl = new ParseACL();
     ParseUser user = new ParseUser();
-    setLazy(user);
+    user.isLazy = true;
     // Since user is a lazy user, this will set the acl's unresolved user and give it write access
     acl.setWriteAccess(user, true);
 
@@ -616,7 +613,7 @@ public class ParseACLTest {
   public void testUnresolvedUser() throws Exception {
     ParseACL acl = new ParseACL();
     ParseUser user = new ParseUser();
-    setLazy(user);
+    user.isLazy = true;
     // This will set unresolvedUser in acl
     acl.setReadAccess(user, true);
 
@@ -625,10 +622,4 @@ public class ParseACLTest {
   }
 
   //endregion
-
-  private static void setLazy(ParseUser user) {
-    Map<String, String> anonymousAuthData = new HashMap<>();
-    anonymousAuthData.put("anonymousToken", "anonymousTest");
-    user.putAuthData(ParseAnonymousUtils.AUTH_TYPE, anonymousAuthData);
-  }
 }

--- a/Parse/src/test/java/com/parse/ParseUserTest.java
+++ b/Parse/src/test/java/com/parse/ParseUserTest.java
@@ -383,7 +383,7 @@ public class ParseUserTest {
     // Register a mock currentUserController to make getCurrentUser work
     ParseUser currentUser = new ParseUser();
     currentUser.putAuthData(ParseAnonymousUtils.AUTH_TYPE, new HashMap<String, String>());
-    setLazy(currentUser);
+    currentUser.isLazy = true;
     ParseUser partialMockCurrentUser = spy(currentUser);
     when(partialMockCurrentUser.getSessionToken()).thenReturn("oldSessionToken");
     doReturn(Task.<ParseUser>forResult(null))
@@ -414,6 +414,7 @@ public class ParseUserTest {
     Map<String, String> oldAnonymousAuthData = new HashMap<>();
     oldAnonymousAuthData.put("oldKey", "oldToken");
     currentUser.putAuthData(ParseAnonymousUtils.AUTH_TYPE, oldAnonymousAuthData);
+    currentUser.isLazy = true;
     ParseUser partialMockCurrentUser = spy(currentUser);
     when(partialMockCurrentUser.getSessionToken()).thenReturn("oldSessionToken");
     doReturn(Task.<ParseUser>forError(new Exception()))
@@ -446,7 +447,6 @@ public class ParseUserTest {
   public void testLoginWithAsyncWithLinkedNotLazyUser() throws Exception {
     // Register a mock currentUserController to make getCurrentUser work
     ParseUser currentUser = new ParseUser();
-    currentUser.setObjectId("objectId"); // Make it not lazy.
     currentUser.putAuthData(ParseAnonymousUtils.AUTH_TYPE, new HashMap<String, String>());
     ParseUser partialMockCurrentUser = spy(currentUser);
     when(partialMockCurrentUser.getSessionToken()).thenReturn("sessionToken");
@@ -483,7 +483,6 @@ public class ParseUserTest {
     // Register a mock currentUserController to make getCurrentUser work
     ParseUser currentUser = new ParseUser();
     currentUser.putAuthData(ParseAnonymousUtils.AUTH_TYPE, new HashMap<String, String>());
-    currentUser.setObjectId("objectId"); // Make it not lazy.
     ParseUser partialMockCurrentUser = spy(currentUser);
     when(partialMockCurrentUser.getSessionToken()).thenReturn("sessionToken");
     ParseException linkException =
@@ -643,9 +642,29 @@ public class ParseUserTest {
   }
 
   @Test
+  public void testResolveLazinessAsyncWithNoAuthData() throws Exception {
+    ParseUser user = new ParseUser();
+    user.isLazy = true;
+    ParseUser partialMockUser = spy(user);
+    doReturn(Task.forResult(null))
+        .when(partialMockUser)
+        .signUpAsync(any(Task.class));
+
+    ParseUser userAfterResolveLaziness =
+        ParseTaskUtils.wait(partialMockUser.resolveLazinessAsync(Task.<Void>forResult(null)));
+
+    // Make sure we signUp the lazy user
+    verify(partialMockUser, times(1)).signUpAsync(any(Task.class));
+    // Make sure the user is not lazy
+    assertFalse(userAfterResolveLaziness.isLazy());
+    // Make sure we do not create new user
+    assertSame(partialMockUser, userAfterResolveLaziness);
+  }
+
+  @Test
   public void testResolveLazinessAsyncWithAuthDataAndNotNewUser() throws Exception {
     ParseUser user = new ParseUser();
-    setLazy(user);
+    user.isLazy = true;
     user.putAuthData("facebook", new HashMap<String, String>());
     // Register a mock userController to make logIn work
     ParseUserController userController = mock(ParseUserController.class);
@@ -683,12 +702,11 @@ public class ParseUserTest {
   @Test
   public void testResolveLazinessAsyncWithAuthDataAndNewUser() throws Exception {
     ParseUser user = new ParseUser();
-    setLazy(user);
+    user.isLazy = true;
     user.putAuthData("facebook", new HashMap<String, String>());
     // Register a mock userController to make logIn work
     ParseUserController userController = mock(ParseUserController.class);
     ParseUser.State newUserState = new ParseUser.State.Builder()
-        .objectId("objectId")
         .put("newKey", "newValue")
         .sessionToken("newSessionToken")
         .isNew(true)
@@ -720,7 +738,7 @@ public class ParseUserTest {
   @Test
   public void testResolveLazinessAsyncWithAuthDataAndNotNewUserAndLDSEnabled() throws Exception {
     ParseUser user = new ParseUser();
-    setLazy(user);
+    user.isLazy = true;
     user.putAuthData("facebook", new HashMap<String, String>());
     // To verify handleSaveResultAsync is not called
     user.setPassword("password");
@@ -776,6 +794,23 @@ public class ParseUserTest {
     user.validateSave();
   }
 
+  @Test
+  public void testValidateSaveWithIsAuthenticated() throws Exception {
+    // Register a mock currentUserController to make getCurrentUser work
+    ParseUser currentUser = new ParseUser();
+    ParseCurrentUserController currentUserController = mock(ParseCurrentUserController.class);
+    when(currentUserController.getAsync(anyBoolean())).thenReturn(Task.<ParseUser>forResult(null));
+    ParseCorePlugins.getInstance().registerCurrentUserController(currentUserController);
+
+    ParseUser user = new ParseUser();
+    user.setObjectId("test");
+    // A lazy user will be an authenticated user. More complicated cases will be covered in
+    // isAuthenticated() unit test.
+    user.isLazy = true;
+
+    user.validateSave();
+  }
+
   // TODO(mengyan): Add testValidateSaveWithIsAuthenticatedWithNotDirty
 
   // TODO(mengyan): Add testValidateSaveWithIsAuthenticatedWithIsCurrentUser
@@ -791,6 +826,8 @@ public class ParseUserTest {
 
     ParseUser user = new ParseUser();
     user.setObjectId("test");
+    // Make isAuthenticated return false
+    user.isLazy = false;
     // Make isDirty return true
     user.put("key", "value");
     // Make isCurrent return false
@@ -810,6 +847,8 @@ public class ParseUserTest {
 
     ParseUser user = new ParseUser();
     user.setObjectId("test");
+    // Make isAuthenticated return false
+    user.isLazy = false;
     // Make isDirty return true
     user.put("key", "value");
     // Make isCurrent return false
@@ -835,10 +874,11 @@ public class ParseUserTest {
 
     // Set facebook authData to null to verify cleanAuthData()
     ParseUser.State userState = new ParseUser.State.Builder()
+        .objectId("test")
         .putAuthData("facebook", null)
         .build();
     ParseUser user = ParseObject.from(userState);
-    setLazy(user);
+    user.isLazy = true;
     user.setIsCurrentUser(true);
     ParseUser partialMockUser = spy(user);
     doReturn(Task.<Void>forResult(null))
@@ -863,10 +903,11 @@ public class ParseUserTest {
 
     // Set facebook authData to null to verify cleanAuthData()
     ParseUser.State userState = new ParseUser.State.Builder()
+        .objectId("test")
         .putAuthData("facebook", null)
         .build();
     ParseUser user = ParseObject.from(userState);
-    setLazy(user);
+    user.isLazy = true;
     user.setIsCurrentUser(false);
     ParseUser partialMockUser = spy(user);
     doReturn(Task.<Void>forResult(null))
@@ -1304,6 +1345,8 @@ public class ParseUserTest {
 
     ParseUser user = new ParseUser();
     user.setObjectId("test");
+    // Make isAuthenticated return false
+    user.isLazy = false;
     // Make isDirty return true
     user.put("key", "value");
 
@@ -1454,10 +1497,4 @@ public class ParseUserTest {
   }
 
   //endregion
-
-  private static void setLazy(ParseUser user) {
-    Map<String, String> anonymousAuthData = new HashMap<>();
-    anonymousAuthData.put("anonymousToken", "anonymousTest");
-    user.putAuthData(ParseAnonymousUtils.AUTH_TYPE, anonymousAuthData);
-  }
 }


### PR DESCRIPTION
Reverts ParsePlatform/Parse-SDK-Android#52

This has an unintended consequence of breaking resolving lazy users via [`signUpAsync`][1] and [`linkWithAsync`][2]. This is due to stripping anonymity [here][3] and [here][4] before calling into [`saveAsync` which has a conditional for `isLazy()`][5], which now wrongly return `false` because we stripped anonymity.

Reverting for now, but a better solution would be to clean up the `resolveLaziness` mess.

[1]: https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/ParseUser.java#L634
[2]: https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/ParseUser.java#L1238
[3]: https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/ParseUser.java#L630
[4]: https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/ParseUser.java#L1229
[5]: https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/ParseUser.java#L480