### PR TITLE
Update ParseCountingByteArrayHttpBodyTest

### DIFF
--- a/Parse/src/test/java/com/parse/ParseCountingByteArrayHttpBodyTest.java
+++ b/Parse/src/test/java/com/parse/ParseCountingByteArrayHttpBodyTest.java
@@ -59,8 +59,8 @@ public class ParseCountingByteArrayHttpBodyTest {
     assertTrue(Arrays.equals(content, output.toByteArray()));
 
     // Check progress callback
-    didReportIntermediateProgress.tryAcquire(5, TimeUnit.SECONDS);
-    finish.tryAcquire(5, TimeUnit.SECONDS);
+    assertTrue(didReportIntermediateProgress.tryAcquire(5, TimeUnit.SECONDS));
+    assertTrue(finish.tryAcquire(5, TimeUnit.SECONDS));
   }
 
   private static byte[] getData() {


### PR DESCRIPTION
We forget to assert when we check the Semaphore