### PR TITLE
Move Method enum to ParseHttpRequest

### DIFF
--- a/Parse/src/main/java/com/parse/EventuallyPin.java
+++ b/Parse/src/main/java/com/parse/EventuallyPin.java
@@ -89,10 +89,10 @@ import bolts.Task;
     int type = TYPE_COMMAND;
     JSONObject json = null;
     if (command.httpPath.startsWith("classes")) {
-      if (command.method == ParseRequest.Method.POST ||
-          command.method == ParseRequest.Method.PUT) {
+      if (command.method == ParseHttpRequest.Method.POST ||
+          command.method == ParseHttpRequest.Method.PUT) {
         type = TYPE_SAVE;
-      } else if (command.method == ParseRequest.Method.DELETE) {
+      } else if (command.method == ParseHttpRequest.Method.DELETE) {
         type = TYPE_DELETE;
       }
     } else {

--- a/Parse/src/main/java/com/parse/ParseAWSRequest.java
+++ b/Parse/src/main/java/com/parse/ParseAWSRequest.java
@@ -20,7 +20,7 @@ import bolts.Task;
  */
 /** package */ class ParseAWSRequest extends ParseRequest<byte[]> {
 
-  public ParseAWSRequest(Method method, String url) {
+  public ParseAWSRequest(ParseHttpRequest.Method method, String url) {
     super(method, url);
   }
 
@@ -31,12 +31,12 @@ import bolts.Task;
     if (statusCode >= 200 && statusCode < 300 || statusCode == 304) {
       // OK
     } else {
-      String action = method == Method.GET ? "Download from" : "Upload to";
+      String action = method == ParseHttpRequest.Method.GET ? "Download from" : "Upload to";
       return Task.forError(new ParseException(ParseException.CONNECTION_FAILED, String.format(
         "%s S3 failed. %s", action, response.getReasonPhrase())));
     }
 
-    if (method != Method.GET) {
+    if (method != ParseHttpRequest.Method.GET) {
       return null;
     }
 

--- a/Parse/src/main/java/com/parse/ParseApacheHttpClient.java
+++ b/Parse/src/main/java/com/parse/ParseApacheHttpClient.java
@@ -173,7 +173,7 @@ import java.util.Map;
     }
 
     HttpUriRequest apacheRequest;
-    ParseRequest.Method method = parseRequest.getMethod();
+    ParseHttpRequest.Method method = parseRequest.getMethod();
     String url = parseRequest.getUrl();
     switch (method) {
       case GET:

--- a/Parse/src/main/java/com/parse/ParseFileController.java
+++ b/Parse/src/main/java/com/parse/ParseFileController.java
@@ -143,7 +143,7 @@ import bolts.Task;
         }
 
         // network
-        final ParseAWSRequest request = new ParseAWSRequest(ParseRequest.Method.GET, state.url());
+        final ParseAWSRequest request = new ParseAWSRequest(ParseHttpRequest.Method.GET, state.url());
 
         // TODO(grantland): Stream response directly to file t5042019
         return request.executeAsync(

--- a/Parse/src/main/java/com/parse/ParseHttpRequest.java
+++ b/Parse/src/main/java/com/parse/ParseHttpRequest.java
@@ -10,12 +10,59 @@ package com.parse;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 /** package */ class ParseHttpRequest {
+
+  public enum Method {
+    GET, POST, PUT, DELETE;
+
+    public static Method fromString(String string) {
+      Method method;
+      switch (string) {
+        case "GET":
+          method = GET;
+          break;
+        case "POST":
+          method = POST;
+          break;
+        case "PUT":
+          method = PUT;
+          break;
+        case "DELETE":
+          method = DELETE;
+          break;
+        default:
+          throw new IllegalArgumentException("Invalid http method: <" + string + ">");
+      }
+      return method;
+    }
+
+    @Override
+    public String toString() {
+      String string;
+      switch (this) {
+        case GET:
+          string = "GET";
+          break;
+        case POST:
+          string = "POST";
+          break;
+        case PUT:
+          string = "PUT";
+          break;
+        case DELETE:
+          string = "DELETE";
+          break;
+        default:
+          throw new IllegalArgumentException("Invalid http method: <" + this+ ">");
+      }
+      return string;
+    }
+  }
+
   private final String url;
-  private final ParseRequest.Method method;
+  private final ParseHttpRequest.Method method;
   private final Map<String, String> headers;
   private final ParseHttpBody body;
 
@@ -30,7 +77,7 @@ import java.util.Map;
     return url;
   }
 
-  public ParseRequest.Method getMethod() {
+  public ParseHttpRequest.Method getMethod() {
     return method;
   }
 
@@ -48,7 +95,7 @@ import java.util.Map;
 
   public static class Builder {
     protected String url;
-    protected ParseRequest.Method method;
+    protected ParseHttpRequest.Method method;
     protected Map<String, String> headers;
     protected ParseHttpBody body;
 
@@ -68,7 +115,7 @@ import java.util.Map;
       return this;
     }
 
-    public Builder setMethod(ParseRequest.Method method) {
+    public Builder setMethod(ParseHttpRequest.Method method) {
       this.method = method;
       return this;
     }

--- a/Parse/src/main/java/com/parse/ParseOkHttpClient.java
+++ b/Parse/src/main/java/com/parse/ParseOkHttpClient.java
@@ -108,7 +108,7 @@ import okio.Okio;
   @Override
   /* package */ Request getRequest(ParseHttpRequest parseRequest) throws IOException {
     Request.Builder okHttpRequestBuilder = new Request.Builder();
-    ParseRequest.Method method = parseRequest.getMethod();
+    ParseHttpRequest.Method method = parseRequest.getMethod();
     // Set method
     switch (method) {
       case GET:
@@ -161,16 +161,16 @@ import okio.Okio;
     // Set method
     switch (okHttpRequest.method()) {
        case OKHTTP_GET:
-           parseRequestBuilder.setMethod(ParseRequest.Method.GET);
+           parseRequestBuilder.setMethod(ParseHttpRequest.Method.GET);
            break;
        case OKHTTP_DELETE:
-           parseRequestBuilder.setMethod(ParseRequest.Method.DELETE);
+           parseRequestBuilder.setMethod(ParseHttpRequest.Method.DELETE);
            break;
        case OKHTTP_POST:
-           parseRequestBuilder.setMethod(ParseRequest.Method.POST);
+           parseRequestBuilder.setMethod(ParseHttpRequest.Method.POST);
            break;
        case OKHTTP_PUT:
-           parseRequestBuilder.setMethod(ParseRequest.Method.PUT);
+           parseRequestBuilder.setMethod(ParseHttpRequest.Method.PUT);
            break;
        default:
            // This should never happen

--- a/Parse/src/main/java/com/parse/ParseRESTAnalyticsCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTAnalyticsCommand.java
@@ -24,7 +24,10 @@ import java.util.Map;
   // Tracks the AppOpened event
   /* package for test */ static final String EVENT_APP_OPENED = "AppOpened";
 
-  public ParseRESTAnalyticsCommand(String httpPath, Method httpMethod, Map<String, ?> parameters,
+  public ParseRESTAnalyticsCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      Map<String, ?> parameters,
       String sessionToken) {
     super(httpPath, httpMethod, parameters, sessionToken);
   }
@@ -57,6 +60,7 @@ import java.util.Map;
       commandParameters.putAll(parameters);
     }
     commandParameters.put("at", NoObjectsEncoder.get().encode(new Date()));
-    return new ParseRESTAnalyticsCommand(httpPath, Method.POST, commandParameters, sessionToken);
+    return new ParseRESTAnalyticsCommand(
+        httpPath, ParseHttpRequest.Method.POST, commandParameters, sessionToken);
   }
 }

--- a/Parse/src/main/java/com/parse/ParseRESTCloudCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTCloudCommand.java
@@ -12,7 +12,10 @@ import java.util.Map;
 
 /** package */ class ParseRESTCloudCommand extends ParseRESTCommand {
 
-  private ParseRESTCloudCommand(String httpPath, Method httpMethod, Map<String, ?> parameters,
+  private ParseRESTCloudCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      Map<String, ?> parameters,
       String sessionToken) {
     super(httpPath, httpMethod, parameters, sessionToken);
   }
@@ -20,6 +23,7 @@ import java.util.Map;
   public static ParseRESTCloudCommand callFunctionCommand(String functionName,
       Map<String, ?> parameters, String sessionToken) {
     final String httpPath = String.format("functions/%s", functionName);
-    return new ParseRESTCloudCommand(httpPath, Method.POST, parameters, sessionToken);
+    return new ParseRESTCloudCommand(
+        httpPath, ParseHttpRequest.Method.POST, parameters, sessionToken);
   }
 }

--- a/Parse/src/main/java/com/parse/ParseRESTCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTCommand.java
@@ -49,7 +49,7 @@ import bolts.Task;
     private String installationId;
     public String masterKey;
 
-    private Method method = Method.GET;
+    private ParseHttpRequest.Method method = ParseHttpRequest.Method.GET;
     private String httpPath;
     private JSONObject jsonParameters;
 
@@ -73,7 +73,7 @@ import bolts.Task;
       return self();
     }
 
-    public T method(Method method) {
+    public T method(ParseHttpRequest.Method method) {
       this.method = method;
       return self();
     }
@@ -121,7 +121,10 @@ import bolts.Task;
   private String operationSetUUID;
   private String localId;
 
-  public ParseRESTCommand(String httpPath, Method httpMethod, Map<String, ?> parameters,
+  public ParseRESTCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      Map<String, ?> parameters,
       String sessionToken) {
     this(
         httpPath,
@@ -130,12 +133,18 @@ import bolts.Task;
         sessionToken);
   }
 
-  protected ParseRESTCommand(String httpPath, Method httpMethod, JSONObject jsonParameters,
+  protected ParseRESTCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      JSONObject jsonParameters,
       String sessionToken) {
     this(httpPath, httpMethod, jsonParameters, null, sessionToken);
   }
 
-  private ParseRESTCommand(String httpPath, Method httpMethod, JSONObject jsonParameters,
+  private ParseRESTCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      JSONObject jsonParameters,
       String localId, String sessionToken) {
     super(httpMethod, createUrl(httpPath));
 
@@ -159,7 +168,8 @@ import bolts.Task;
 
   public static ParseRESTCommand fromJSONObject(JSONObject jsonObject) {
     String httpPath = jsonObject.optString("httpPath");
-    Method httpMethod = Method.fromString(jsonObject.optString("httpMethod"));
+    ParseHttpRequest.Method httpMethod =
+        ParseHttpRequest.Method.fromString(jsonObject.optString("httpMethod"));
     String sessionToken = jsonObject.optString("sessionToken", null);
     String localId = jsonObject.optString("localId", null);
     JSONObject jsonParameters = jsonObject.optJSONObject("parameters");
@@ -192,17 +202,17 @@ import bolts.Task;
 
   @Override
   protected ParseHttpRequest newRequest(
-      Method method,
+      ParseHttpRequest.Method method,
       String url,
       ProgressCallback uploadProgressCallback) {
     ParseHttpRequest request;
     if (jsonParameters != null &&
-        method != Method.POST &&
-        method != Method.PUT) {
+        method != ParseHttpRequest.Method.POST &&
+        method != ParseHttpRequest.Method.PUT) {
       // The request URI may be too long to include parameters in the URI.
       // To avoid this problem we send the parameters in a POST request json-encoded body
       // and add a http method override parameter in newBody.
-      request = super.newRequest(Method.POST, url, uploadProgressCallback);
+      request = super.newRequest(ParseHttpRequest.Method.POST, url, uploadProgressCallback);
     } else {
       request = super.newRequest(method, url, uploadProgressCallback);
     }
@@ -221,8 +231,8 @@ import bolts.Task;
 
     try {
       JSONObject parameters = jsonParameters;
-      if (method == Method.GET ||
-          method == Method.DELETE) {
+      if (method == ParseHttpRequest.Method.GET ||
+          method == ParseHttpRequest.Method.DELETE) {
         // The request URI may be too long to include parameters in the URI.
         // To avoid this problem we send the parameters in a POST request json-encoded body
         // and add a http method override parameter.
@@ -421,8 +431,8 @@ import bolts.Task;
         httpPath += String.format("/%s", objectId);
         url = createUrl(httpPath);
 
-        if (httpPath.startsWith("classes") && method == Method.POST) {
-          method = Method.PUT;
+        if (httpPath.startsWith("classes") && method == ParseHttpRequest.Method.POST) {
+          method = ParseHttpRequest.Method.PUT;
         }
       }
     }

--- a/Parse/src/main/java/com/parse/ParseRESTConfigCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTConfigCommand.java
@@ -13,22 +13,26 @@ import java.util.Map;
 
 /** package */ class ParseRESTConfigCommand extends ParseRESTCommand {
 
-  public ParseRESTConfigCommand(String httpPath, Method httpMethod, Map<String, ?> parameters,
+  public ParseRESTConfigCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      Map<String, ?> parameters,
       String sessionToken) {
     super(httpPath, httpMethod, parameters, sessionToken);
   }
 
   public static ParseRESTConfigCommand fetchConfigCommand(String sessionToken) {
-    return new ParseRESTConfigCommand("config", Method.GET, null, sessionToken);
+    return new ParseRESTConfigCommand("config", ParseHttpRequest.Method.GET, null, sessionToken);
   }
 
-  public static ParseRESTConfigCommand updateConfigCommand(final Map<String, ?> configParameters,
-      String sessionToken) {
+  public static ParseRESTConfigCommand updateConfigCommand(
+      final Map<String, ?> configParameters, String sessionToken) {
     Map<String, Map<String, ?>> commandParameters = null;
     if (configParameters != null) {
       commandParameters = new HashMap<>();
       commandParameters.put("params", configParameters);
     }
-    return new ParseRESTConfigCommand("config", Method.PUT, commandParameters, sessionToken);
+    return new ParseRESTConfigCommand(
+        "config", ParseHttpRequest.Method.PUT, commandParameters, sessionToken);
   }
 }

--- a/Parse/src/main/java/com/parse/ParseRESTFileCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTFileCommand.java
@@ -20,7 +20,7 @@ package com.parse;
 
     public Builder() {
       // We only ever use ParseRESTFileCommand for file uploads, so default to POST.
-      method(Method.POST);
+      method(ParseHttpRequest.Method.POST);
     }
 
     public Builder fileName(String fileName) {

--- a/Parse/src/main/java/com/parse/ParseRESTObjectBatchCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTObjectBatchCommand.java
@@ -75,7 +75,7 @@ import bolts.Task;
     Map<String, List<JSONObject>> parameters = new HashMap<>();
     parameters.put("requests", requests);
     ParseRESTCommand command = new ParseRESTObjectBatchCommand(
-        "batch", Method.POST, parameters, sessionToken);
+        "batch", ParseHttpRequest.Method.POST, parameters, sessionToken);
 
     command.executeAsync(client).continueWith(new Continuation<JSONObject, Void>() {
       @Override
@@ -126,7 +126,10 @@ import bolts.Task;
     return tasks;
   }
 
-  private ParseRESTObjectBatchCommand(String httpPath, Method httpMethod, Map<String, ?> parameters,
+  private ParseRESTObjectBatchCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      Map<String, ?> parameters,
       String sessionToken) {
     super(httpPath, httpMethod, parameters, sessionToken);
   }

--- a/Parse/src/main/java/com/parse/ParseRESTObjectCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTObjectCommand.java
@@ -17,7 +17,10 @@ import java.util.Map;
 
 /** package */ class ParseRESTObjectCommand extends ParseRESTCommand {
 
-  public ParseRESTObjectCommand(String httpPath, Method httpMethod, JSONObject parameters,
+  public ParseRESTObjectCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      JSONObject parameters,
       String sessionToken) {
     super(httpPath, httpMethod, parameters, sessionToken);
   }
@@ -25,7 +28,7 @@ import java.util.Map;
   public static ParseRESTObjectCommand getObjectCommand(String objectId, String className,
       String sessionToken) {
     String httpPath = String.format("classes/%s/%s", Uri.encode(className), Uri.encode(objectId));
-    return new ParseRESTObjectCommand(httpPath, Method.GET, null, sessionToken);
+    return new ParseRESTObjectCommand(httpPath, ParseHttpRequest.Method.GET, null, sessionToken);
   }
 
   public static ParseRESTObjectCommand saveObjectCommand(
@@ -47,13 +50,13 @@ import java.util.Map;
   private static ParseRESTObjectCommand createObjectCommand(String className, JSONObject changes,
       String sessionToken) {
     String httpPath = String.format("classes/%s", Uri.encode(className));
-    return new ParseRESTObjectCommand(httpPath, Method.POST, changes, sessionToken);
+    return new ParseRESTObjectCommand(httpPath, ParseHttpRequest.Method.POST, changes, sessionToken);
   }
 
   private static ParseRESTObjectCommand updateObjectCommand(String objectId, String className,
       JSONObject changes, String sessionToken) {
     String httpPath = String.format("classes/%s/%s", Uri.encode(className), Uri.encode(objectId));
-    return new ParseRESTObjectCommand(httpPath, Method.PUT, changes, sessionToken);
+    return new ParseRESTObjectCommand(httpPath, ParseHttpRequest.Method.PUT, changes, sessionToken);
   }
 
   public static ParseRESTObjectCommand deleteObjectCommand(
@@ -63,6 +66,6 @@ import java.util.Map;
     if (objectId != null) {
       httpPath += String.format("/%s", Uri.encode(objectId));
     }
-    return new ParseRESTObjectCommand(httpPath, Method.DELETE, null, sessionToken);
+    return new ParseRESTObjectCommand(httpPath, ParseHttpRequest.Method.DELETE, null, sessionToken);
   }
 }

--- a/Parse/src/main/java/com/parse/ParseRESTPushCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTPushCommand.java
@@ -25,7 +25,10 @@ import java.util.Set;
   /* package */ final static String KEY_EXPIRATION_INTERVAL = "expiration_interval";
   /* package */ final static String KEY_DATA = "data";
 
-  public ParseRESTPushCommand(String httpPath, Method httpMethod, Map<String, ?> parameters,
+  public ParseRESTPushCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      Map<String, ?> parameters,
       String sessionToken) {
     super(httpPath, httpMethod, parameters, sessionToken);
   }
@@ -68,6 +71,6 @@ import java.util.Set;
       parameters.put(KEY_DATA, payload);
     }
 
-    return new ParseRESTPushCommand("push", Method.POST, parameters, sessionToken);
+    return new ParseRESTPushCommand("push", ParseHttpRequest.Method.POST, parameters, sessionToken);
   }
 }

--- a/Parse/src/main/java/com/parse/ParseRESTQueryCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTQueryCommand.java
@@ -21,14 +21,16 @@ import java.util.Set;
       ParseQuery.State<T> state, String sessionToken) {
     String httpPath = String.format("classes/%s", state.className());
     Map <String, String> parameters = encode(state, false);
-    return new ParseRESTQueryCommand(httpPath, Method.GET, parameters, sessionToken);
+    return new ParseRESTQueryCommand(
+        httpPath, ParseHttpRequest.Method.GET, parameters, sessionToken);
   }
 
   public static <T extends ParseObject> ParseRESTQueryCommand countCommand(
       ParseQuery.State<T> state, String sessionToken) {
     String httpPath = String.format("classes/%s", state.className());
     Map <String, String> parameters = encode(state, true);
-    return new ParseRESTQueryCommand(httpPath, Method.GET, parameters, sessionToken);
+    return new ParseRESTQueryCommand(
+        httpPath, ParseHttpRequest.Method.GET, parameters, sessionToken);
   }
 
   /* package */ static <T extends ParseObject> Map<String, String> encode(
@@ -84,7 +86,10 @@ import java.util.Set;
     return parameters;
   }
 
-  private ParseRESTQueryCommand(String httpPath, Method httpMethod, Map<String, ?> parameters,
+  private ParseRESTQueryCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      Map<String, ?> parameters,
       String sessionToken) {
     super(httpPath, httpMethod, parameters, sessionToken);
   }

--- a/Parse/src/main/java/com/parse/ParseRESTSessionCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTSessionCommand.java
@@ -13,19 +13,24 @@ import org.json.JSONObject;
 /** package */ class ParseRESTSessionCommand extends ParseRESTCommand {
 
   public static ParseRESTSessionCommand getCurrentSessionCommand(String sessionToken) {
-    return new ParseRESTSessionCommand("sessions/me", Method.GET, null, sessionToken);
+    return new ParseRESTSessionCommand(
+        "sessions/me", ParseHttpRequest.Method.GET, null, sessionToken);
   }
 
   public static ParseRESTSessionCommand revoke(String sessionToken) {
-    return new ParseRESTSessionCommand("logout", Method.POST, new JSONObject(), sessionToken);
+    return new ParseRESTSessionCommand(
+        "logout", ParseHttpRequest.Method.POST, new JSONObject(), sessionToken);
   }
 
   public static ParseRESTSessionCommand upgradeToRevocableSessionCommand(String sessionToken) {
     return new ParseRESTSessionCommand(
-        "upgradeToRevocableSession", Method.POST, new JSONObject(), sessionToken);
+        "upgradeToRevocableSession", ParseHttpRequest.Method.POST, new JSONObject(), sessionToken);
   }
 
-  private ParseRESTSessionCommand(String httpPath, Method httpMethod, JSONObject jsonParameters,
+  private ParseRESTSessionCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      JSONObject jsonParameters,
       String sessionToken) {
     super(httpPath, httpMethod, jsonParameters, sessionToken);
   }

--- a/Parse/src/main/java/com/parse/ParseRESTUserCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTUserCommand.java
@@ -22,15 +22,15 @@ import bolts.Task;
   private static final String HEADER_TRUE = "1";
 
   public static ParseRESTUserCommand getCurrentUserCommand(String sessionToken) {
-    return new ParseRESTUserCommand("users/me", Method.GET, null, sessionToken);
+    return new ParseRESTUserCommand("users/me", ParseHttpRequest.Method.GET, null, sessionToken);
   }
 
   //region Authentication
 
   public static ParseRESTUserCommand signUpUserCommand(JSONObject parameters, String sessionToken,
       boolean revocableSession) {
-    return new ParseRESTUserCommand("classes/_User", Method.POST, parameters, sessionToken,
-        revocableSession);
+    return new ParseRESTUserCommand(
+        "classes/_User", ParseHttpRequest.Method.POST, parameters, sessionToken, revocableSession);
   }
 
   public static ParseRESTUserCommand logInUserCommand(String username, String password,
@@ -38,7 +38,8 @@ import bolts.Task;
     Map<String, String> parameters = new HashMap<>();
     parameters.put("username", username);
     parameters.put("password", password);
-    return new ParseRESTUserCommand("login", Method.GET, parameters, null, revocableSession);
+    return new ParseRESTUserCommand(
+        "login", ParseHttpRequest.Method.GET, parameters, null, revocableSession);
   }
 
   public static ParseRESTUserCommand serviceLogInUserCommand(
@@ -61,8 +62,8 @@ import bolts.Task;
 
   public static ParseRESTUserCommand serviceLogInUserCommand(JSONObject parameters,
       String sessionToken, boolean revocableSession) {
-    return new ParseRESTUserCommand("users", Method.POST, parameters, sessionToken,
-        revocableSession);
+    return new ParseRESTUserCommand(
+        "users", ParseHttpRequest.Method.POST, parameters, sessionToken, revocableSession);
   }
 
   //endregion
@@ -70,24 +71,34 @@ import bolts.Task;
   public static ParseRESTUserCommand resetPasswordResetCommand(String email) {
     Map<String, String> parameters = new HashMap<>();
     parameters.put("email", email);
-    return new ParseRESTUserCommand("requestPasswordReset", Method.POST, parameters, null);
+    return new ParseRESTUserCommand(
+        "requestPasswordReset", ParseHttpRequest.Method.POST, parameters, null);
   }
 
   private boolean isRevocableSessionEnabled;
   private int statusCode;
 
-  private ParseRESTUserCommand(String httpPath, Method httpMethod, Map<String, ?> parameters,
+  private ParseRESTUserCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      Map<String, ?> parameters,
       String sessionToken) {
     this(httpPath, httpMethod, parameters, sessionToken, false);
   }
 
-  private ParseRESTUserCommand(String httpPath, Method httpMethod, Map<String, ?> parameters,
+  private ParseRESTUserCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      Map<String, ?> parameters,
       String sessionToken, boolean isRevocableSessionEnabled) {
     super(httpPath, httpMethod, parameters, sessionToken);
     this.isRevocableSessionEnabled = isRevocableSessionEnabled;
   }
 
-  private ParseRESTUserCommand(String httpPath, Method httpMethod, JSONObject parameters,
+  private ParseRESTUserCommand(
+      String httpPath,
+      ParseHttpRequest.Method httpMethod,
+      JSONObject parameters,
       String sessionToken, boolean isRevocableSessionEnabled) {
     super(httpPath, httpMethod, parameters, sessionToken);
     this.isRevocableSessionEnabled = isRevocableSessionEnabled;

--- a/Parse/src/main/java/com/parse/ParseRequest.java
+++ b/Parse/src/main/java/com/parse/ParseRequest.java
@@ -61,53 +61,6 @@ import bolts.Task;
       CORE_POOL_SIZE, MAX_POOL_SIZE, KEEP_ALIVE_TIME, TimeUnit.SECONDS,
       new LinkedBlockingQueue<Runnable>(MAX_QUEUE_SIZE), sThreadFactory);
 
-  public enum Method {
-    GET, POST, PUT, DELETE;
-
-    public static Method fromString(String string) {
-      Method method = null;
-      switch (string) {
-        case "GET":
-          method = GET;
-          break;
-        case "POST":
-          method = POST;
-          break;
-        case "PUT":
-          method = PUT;
-          break;
-        case "DELETE":
-          method = DELETE;
-          break;
-        default:
-          break;
-      }
-      return method;
-    }
-
-    @Override
-    public String toString() {
-      String string = null;
-      switch (this) {
-        case GET:
-          string = "GET";
-          break;
-        case POST:
-          string = "POST";
-          break;
-        case PUT:
-          string = "PUT";
-          break;
-        case DELETE:
-          string = "DELETE";
-          break;
-        default:
-          break;
-      }
-      return string;
-    }
-  }
-
   protected static final int DEFAULT_MAX_RETRIES = 4;
   /* package */ static final long DEFAULT_INITIAL_RETRY_DELAY = 1000L;
 
@@ -137,14 +90,14 @@ import bolts.Task;
 
   private int maxRetries = DEFAULT_MAX_RETRIES;
 
-  /* package */ Method method;
+  /* package */ ParseHttpRequest.Method method;
   /* package */ String url;
 
   public ParseRequest(String url) {
-    this(Method.GET, url);
+    this(ParseHttpRequest.Method.GET, url);
   }
 
-  public ParseRequest(Method method, String url) {
+  public ParseRequest(ParseHttpRequest.Method method, String url) {
     this.method = method;
     this.url = url;
   }
@@ -159,7 +112,7 @@ import bolts.Task;
   }
 
   protected ParseHttpRequest newRequest(
-      Method method,
+      ParseHttpRequest.Method method,
       String url,
       ProgressCallback uploadProgressCallback)  {
     ParseHttpRequest.Builder requestBuilder = new ParseHttpRequest.Builder()

--- a/Parse/src/test/java/com/parse/ParseAWSRequestTest.java
+++ b/Parse/src/test/java/com/parse/ParseAWSRequestTest.java
@@ -44,7 +44,7 @@ public class ParseAWSRequestTest extends TestCase {
     ParseHttpClient mockHttpClient = mock(ParseHttpClient.class);
     when(mockHttpClient.execute(any(ParseHttpRequest.class))).thenReturn(mockResponse);
 
-    ParseAWSRequest request = new ParseAWSRequest(ParseRequest.Method.GET, "http://parse.com");
+    ParseAWSRequest request = new ParseAWSRequest(ParseHttpRequest.Method.GET, "http://parse.com");
     Task<byte[]> task = request.executeAsync(mockHttpClient);
     task.waitForCompletion();
 

--- a/Parse/src/test/java/com/parse/ParseApacheHttpClientTest.java
+++ b/Parse/src/test/java/com/parse/ParseApacheHttpClientTest.java
@@ -47,7 +47,7 @@ public class ParseApacheHttpClientTest {
 
     // Get
     ParseHttpRequest parseRequest = builder
-        .setMethod(ParseRequest.Method.GET)
+        .setMethod(ParseHttpRequest.Method.GET)
         .setBody(null)
         .build();
     HttpUriRequest apacheRequest = parseClient.getRequest(parseRequest);
@@ -55,7 +55,7 @@ public class ParseApacheHttpClientTest {
 
     // Post
     parseRequest = builder
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody("test", "application/json"))
         .build();
     apacheRequest = parseClient.getRequest(parseRequest);
@@ -63,7 +63,7 @@ public class ParseApacheHttpClientTest {
 
     // Delete
     parseRequest = builder
-        .setMethod(ParseRequest.Method.DELETE)
+        .setMethod(ParseHttpRequest.Method.DELETE)
         .setBody(null)
         .build();
     apacheRequest = parseClient.getRequest(parseRequest);
@@ -71,7 +71,7 @@ public class ParseApacheHttpClientTest {
 
     // Put
     parseRequest = builder
-        .setMethod(ParseRequest.Method.PUT)
+        .setMethod(ParseHttpRequest.Method.PUT)
         .setBody(new ParseByteArrayHttpBody("test", "application/json"))
         .build();
     apacheRequest = parseClient.getRequest(parseRequest);
@@ -89,7 +89,7 @@ public class ParseApacheHttpClientTest {
     String contentType = "application/json";
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
         .setUrl(url)
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody(content, contentType))
         .setHeaders(headers)
         .build();
@@ -123,7 +123,7 @@ public class ParseApacheHttpClientTest {
     String content = "test";
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
         .setUrl(url)
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody(content, null))
         .build();
 

--- a/Parse/src/test/java/com/parse/ParseDecompressInterceptorTest.java
+++ b/Parse/src/test/java/com/parse/ParseDecompressInterceptorTest.java
@@ -41,7 +41,7 @@ public class ParseDecompressInterceptorTest {
         // Generate test request
         return new ParseHttpRequest.Builder()
             .setUrl("www.parse.com")
-            .setMethod(ParseRequest.Method.GET)
+            .setMethod(ParseHttpRequest.Method.GET)
             .build();
       }
 
@@ -79,7 +79,7 @@ public class ParseDecompressInterceptorTest {
         // Generate test request
         return new ParseHttpRequest.Builder()
             .setUrl("www.parse.com")
-            .setMethod(ParseRequest.Method.GET)
+            .setMethod(ParseHttpRequest.Method.GET)
             .build();
       }
 

--- a/Parse/src/test/java/com/parse/ParseHttpClientTest.java
+++ b/Parse/src/test/java/com/parse/ParseHttpClientTest.java
@@ -114,7 +114,7 @@ public class ParseHttpClientTest {
     String requestContentType = "application/json";
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
         .setUrl(requestUrl)
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody(requestContent, requestContentType))
         .setHeaders(requestHeaders)
         .build();
@@ -125,7 +125,7 @@ public class ParseHttpClientTest {
     RecordedRequest recordedApacheRequest = server.takeRequest();
 
     // Verify request method
-    assertEquals(ParseRequest.Method.POST.toString(), recordedApacheRequest.getMethod());
+    assertEquals(ParseHttpRequest.Method.POST.toString(), recordedApacheRequest.getMethod());
 
     // Verify request headers, since http library automatically adds some headers, we only need to
     // verify all parseRequest headers are in recordedRequest headers.
@@ -184,7 +184,7 @@ public class ParseHttpClientTest {
     String requestUrl = server.getUrl("/").toString();
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
         .setUrl(requestUrl)
-        .setMethod(ParseRequest.Method.GET)
+        .setMethod(ParseHttpRequest.Method.GET)
         .build();
 
     // Execute request
@@ -193,7 +193,7 @@ public class ParseHttpClientTest {
     RecordedRequest recordedRequest = server.takeRequest();
 
     // Verify request method
-    assertEquals(ParseRequest.Method.GET.toString(), recordedRequest.getMethod());
+    assertEquals(ParseHttpRequest.Method.GET.toString(), recordedRequest.getMethod());
 
     // Verify request headers
     Headers recordedHeaders = recordedRequest.getHeaders();

--- a/Parse/src/test/java/com/parse/ParseHttpRequestTest.java
+++ b/Parse/src/test/java/com/parse/ParseHttpRequestTest.java
@@ -24,7 +24,7 @@ public class ParseHttpRequestTest {
   @Test
   public void testParseHttpRequestGetMethod() throws IOException {
     String url = "www.parse.com";
-    ParseRequest.Method method = ParseRequest.Method.POST;
+    ParseHttpRequest.Method method = ParseHttpRequest.Method.POST;
     Map<String, String> headers = new HashMap<>();
     String name = "name";
     String value = "value";
@@ -53,7 +53,7 @@ public class ParseHttpRequestTest {
   @Test
   public void testParseHttpRequestBuilderInitialization() throws IOException {
     String url = "www.parse.com";
-    ParseRequest.Method method = ParseRequest.Method.POST;
+    ParseHttpRequest.Method method = ParseHttpRequest.Method.POST;
     Map<String, String> headers = new HashMap<>();
     String name = "name";
     String value = "value";

--- a/Parse/src/test/java/com/parse/ParseLogInterceptorTest.java
+++ b/Parse/src/test/java/com/parse/ParseLogInterceptorTest.java
@@ -58,7 +58,7 @@ public class ParseLogInterceptorTest {
       @Override
       public ParseHttpRequest getRequest() {
         // We do not need request for this test so we simply return an empty request
-        return new ParseHttpRequest.Builder().setMethod(ParseRequest.Method.GET).build();
+        return new ParseHttpRequest.Builder().setMethod(ParseHttpRequest.Method.GET).build();
       }
 
       @Override
@@ -108,7 +108,7 @@ public class ParseLogInterceptorTest {
       @Override
       public ParseHttpRequest getRequest() {
         // We do not need request for this test so we simply return an empty request
-        return new ParseHttpRequest.Builder().setMethod(ParseRequest.Method.GET).build();
+        return new ParseHttpRequest.Builder().setMethod(ParseHttpRequest.Method.GET).build();
       }
 
       @Override
@@ -158,7 +158,7 @@ public class ParseLogInterceptorTest {
       @Override
       public ParseHttpRequest getRequest() {
         // We do not need request for this test so we simply return an empty request
-        return new ParseHttpRequest.Builder().setMethod(ParseRequest.Method.GET).build();
+        return new ParseHttpRequest.Builder().setMethod(ParseHttpRequest.Method.GET).build();
       }
 
       @Override

--- a/Parse/src/test/java/com/parse/ParseOkHttpClientTest.java
+++ b/Parse/src/test/java/com/parse/ParseOkHttpClientTest.java
@@ -58,35 +58,35 @@ public class ParseOkHttpClientTest {
 
     // Get
     ParseHttpRequest parseRequest = builder
-        .setMethod(ParseRequest.Method.GET)
+        .setMethod(ParseHttpRequest.Method.GET)
         .setBody(null)
         .build();
     Request okHttpRequest = parseClient.getRequest(parseRequest);
-    assertEquals(ParseRequest.Method.GET.toString(), okHttpRequest.method());
+    assertEquals(ParseHttpRequest.Method.GET.toString(), okHttpRequest.method());
 
     // Post
     parseRequest = builder
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody("test", "application/json"))
         .build();
     okHttpRequest = parseClient.getRequest(parseRequest);
-    assertEquals(ParseRequest.Method.POST.toString(), okHttpRequest.method());
+    assertEquals(ParseHttpRequest.Method.POST.toString(), okHttpRequest.method());
 
     // Delete
     parseRequest = builder
-        .setMethod(ParseRequest.Method.DELETE)
+        .setMethod(ParseHttpRequest.Method.DELETE)
         .setBody(null)
         .build();
     okHttpRequest = parseClient.getRequest(parseRequest);
-    assertEquals(ParseRequest.Method.DELETE.toString(), okHttpRequest.method());
+    assertEquals(ParseHttpRequest.Method.DELETE.toString(), okHttpRequest.method());
 
     // Put
     parseRequest = builder
-        .setMethod(ParseRequest.Method.PUT)
+        .setMethod(ParseHttpRequest.Method.PUT)
         .setBody(new ParseByteArrayHttpBody("test", "application/json"))
         .build();
     okHttpRequest = parseClient.getRequest(parseRequest);
-    assertEquals(ParseRequest.Method.PUT.toString(), okHttpRequest.method());
+    assertEquals(ParseHttpRequest.Method.PUT.toString(), okHttpRequest.method());
   }
 
   @Test
@@ -102,7 +102,7 @@ public class ParseOkHttpClientTest {
     String contentType = "application/json";
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
         .setUrl(url)
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody(content, contentType))
         .setHeaders(headers)
         .build();
@@ -111,7 +111,7 @@ public class ParseOkHttpClientTest {
     Request okHttpRequest = parseClient.getRequest(parseRequest);
 
     // Verify method
-    assertEquals(ParseRequest.Method.POST.toString(), okHttpRequest.method());
+    assertEquals(ParseHttpRequest.Method.POST.toString(), okHttpRequest.method());
     // Verify URL
     assertEquals(url, okHttpRequest.urlString());
     // Verify Headers
@@ -136,7 +136,7 @@ public class ParseOkHttpClientTest {
     String content = "test";
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
         .setUrl(url)
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody(content, null))
         .build();
 
@@ -252,7 +252,7 @@ public class ParseOkHttpClientTest {
     String requestUrl = server.getUrl("/").toString();
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
         .setUrl(requestUrl)
-        .setMethod(ParseRequest.Method.GET)
+        .setMethod(ParseHttpRequest.Method.GET)
         .build();
 
     // Execute request
@@ -357,7 +357,7 @@ public class ParseOkHttpClientTest {
     json.put("key", "value");
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
         .setUrl(server.getUrl("/").toString())
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody(json.toString().getBytes(), "application/json"))
         .setHeaders(headers)
         .build();
@@ -368,7 +368,7 @@ public class ParseOkHttpClientTest {
   // sure you also change the condition in this method otherwise tests will fail
   private void verifyClientRequest(ParseHttpRequest parseRequest) throws IOException {
     assertEquals(server.getUrl("/").toString(), parseRequest.getUrl());
-    assertEquals(ParseRequest.Method.POST, parseRequest.getMethod());
+    assertEquals(ParseHttpRequest.Method.POST, parseRequest.getMethod());
     assertEquals("requestValue", parseRequest.getHeader("requestKey"));
     assertEquals("application/json", parseRequest.getBody().getContentType());
     JSONObject json = new JSONObject();
@@ -388,7 +388,7 @@ public class ParseOkHttpClientTest {
         new ParseHttpRequest.Builder()
             .addHeader("requestKeyAgain", "requestValueAgain")
             .setUrl(server.getUrl("/test").toString())
-            .setMethod(ParseRequest.Method.GET)
+            .setMethod(ParseHttpRequest.Method.GET)
             .build();
     return requestAgain;
   }
@@ -397,7 +397,7 @@ public class ParseOkHttpClientTest {
   // sure you also change the condition in this method otherwise tests will fail
   private void verifyInterceptorRequest(RecordedRequest recordedRequest) throws IOException {
     assertEquals("/test", recordedRequest.getPath());
-    assertEquals(ParseRequest.Method.GET.toString(), recordedRequest.getMethod());
+    assertEquals(ParseHttpRequest.Method.GET.toString(), recordedRequest.getMethod());
     assertEquals("requestValueAgain", recordedRequest.getHeader("requestKeyAgain"));
   }
 

--- a/Parse/src/test/java/com/parse/ParseRESTCommandTest.java
+++ b/Parse/src/test/java/com/parse/ParseRESTCommandTest.java
@@ -83,7 +83,7 @@ public class ParseRESTCommandTest {
     when(client.execute(any(ParseHttpRequest.class))).thenReturn(response);
 
     ParseRESTCommand command = new ParseRESTCommand.Builder()
-        .method(ParseRequest.Method.GET)
+        .method(ParseHttpRequest.Method.GET)
         .installationId("fake_installation_id")
         .build();
     Task<JSONObject> task = command.executeAsync(client);
@@ -116,7 +116,7 @@ public class ParseRESTCommandTest {
     );
 
     ParseRESTCommand command = new ParseRESTCommand.Builder()
-        .method(ParseRequest.Method.GET)
+        .method(ParseHttpRequest.Method.GET)
         .installationId("fake_installation_id")
         .build();
     Task<JSONObject> task = command.executeAsync(client);
@@ -141,7 +141,7 @@ public class ParseRESTCommandTest {
     when(client.execute(any(ParseHttpRequest.class))).thenReturn(response);
 
     ParseRESTCommand command = new ParseRESTCommand.Builder()
-        .method(ParseRequest.Method.GET)
+        .method(ParseHttpRequest.Method.GET)
         .installationId("fake_installation_id")
         .build();
     Task<JSONObject> task = command.executeAsync(client);
@@ -189,7 +189,7 @@ public class ParseRESTCommandTest {
     ParseRESTCommand command = new ParseRESTCommand.Builder()
         .httpPath(httpPath)
         .jsonParameters(jsonParameters)
-        .method(ParseRequest.Method.POST)
+        .method(ParseHttpRequest.Method.POST)
         .sessionToken(sessionToken)
         .localId(localId)
         .build();
@@ -215,7 +215,7 @@ public class ParseRESTCommandTest {
     ParseRESTCommand command = new ParseRESTCommand.Builder()
         .httpPath(httpPath)
         .jsonParameters(jsonParameters)
-        .method(ParseRequest.Method.POST)
+        .method(ParseHttpRequest.Method.POST)
         .sessionToken(sessionToken)
         .localId(localId)
         .build();
@@ -223,7 +223,7 @@ public class ParseRESTCommandTest {
     String cacheKey = command.getCacheKey();
 
     assertTrue(cacheKey.contains("ParseRESTCommand"));
-    assertTrue(cacheKey.contains(ParseRequest.Method.POST.toString()));
+    assertTrue(cacheKey.contains(ParseHttpRequest.Method.POST.toString()));
     assertTrue(cacheKey.contains(ParseDigestUtils.md5(httpPath)));
     String str =
         ParseDigestUtils.md5(ParseRESTCommand.toDeterministicString(jsonParameters) + sessionToken);
@@ -238,7 +238,7 @@ public class ParseRESTCommandTest {
     String localId = "localId";
     ParseRESTCommand command = new ParseRESTCommand.Builder()
         .httpPath(httpPath)
-        .method(ParseRequest.Method.POST)
+        .method(ParseHttpRequest.Method.POST)
         .sessionToken(sessionToken)
         .localId(localId)
         .build();
@@ -246,7 +246,7 @@ public class ParseRESTCommandTest {
     String cacheKey = command.getCacheKey();
 
     assertTrue(cacheKey.contains("ParseRESTCommand"));
-    assertTrue(cacheKey.contains(ParseRequest.Method.POST.toString()));
+    assertTrue(cacheKey.contains(ParseHttpRequest.Method.POST.toString()));
     assertTrue(cacheKey.contains(ParseDigestUtils.md5(httpPath)));
     assertTrue(cacheKey.contains(ParseDigestUtils.md5(sessionToken)));
   }
@@ -269,7 +269,7 @@ public class ParseRESTCommandTest {
     ParseRESTCommand command = new ParseRESTCommand.Builder()
         .httpPath(httpPath)
         .jsonParameters(jsonParameters)
-        .method(ParseRequest.Method.POST)
+        .method(ParseHttpRequest.Method.POST)
         .sessionToken(sessionToken)
         .localId(localId)
         .build();
@@ -298,7 +298,7 @@ public class ParseRESTCommandTest {
     ParseRESTCommand command = new ParseRESTCommand.Builder()
         .httpPath(httpPath)
         .jsonParameters(jsonParameters)
-        .method(ParseRequest.Method.POST)
+        .method(ParseHttpRequest.Method.POST)
         .sessionToken(sessionToken)
         .localId(localId)
         .build();
@@ -331,7 +331,7 @@ public class ParseRESTCommandTest {
     ParseRESTCommand command = new ParseRESTCommand.Builder()
         .httpPath(httpPath)
         .jsonParameters(jsonParameters)
-        .method(ParseRequest.Method.POST)
+        .method(ParseHttpRequest.Method.POST)
         .sessionToken(sessionToken)
         .localId(localId)
         .build();
@@ -346,7 +346,7 @@ public class ParseRESTCommandTest {
     // Make sure localId in command has been replaced with objectId
     assertNull(command.getLocalId());
     // Make sure httpMethod has been changed
-    assertEquals(ParseRequest.Method.PUT, command.method);
+    assertEquals(ParseHttpRequest.Method.PUT, command.method);
     // Make sure objectId has been added to httpPath
     assertTrue(command.httpPath.contains("objectId"));
   }
@@ -369,7 +369,7 @@ public class ParseRESTCommandTest {
     ParseRESTCommand command = new ParseRESTCommand.Builder()
         .httpPath(httpPath)
         .jsonParameters(jsonParameters)
-        .method(ParseRequest.Method.POST)
+        .method(ParseHttpRequest.Method.POST)
         .sessionToken(sessionToken)
         .localId(localId)
         .build();
@@ -388,14 +388,14 @@ public class ParseRESTCommandTest {
     String localId = "localId";
     ParseRESTCommand command = new ParseRESTCommand.Builder()
         .httpPath(httpPath)
-        .method(ParseRequest.Method.GET)
+        .method(ParseHttpRequest.Method.GET)
         .sessionToken(sessionToken)
         .localId(localId)
         .build();
 
     thrown.expect(IllegalArgumentException.class);
     String message = String.format("Trying to execute a %s command without body parameters.",
-        ParseRequest.Method.GET.toString());
+        ParseHttpRequest.Method.GET.toString());
     thrown.expectMessage(message);
     
     command.newBody(null);
@@ -413,7 +413,7 @@ public class ParseRESTCommandTest {
     ParseRESTCommand command = new ParseRESTCommand.Builder()
         .httpPath(httpPath)
         .jsonParameters(jsonParameters)
-        .method(ParseRequest.Method.GET)
+        .method(ParseHttpRequest.Method.GET)
         .sessionToken(sessionToken)
         .localId(localId)
         .build();
@@ -424,7 +424,7 @@ public class ParseRESTCommandTest {
     JSONObject json = new JSONObject(new String(ParseIOUtils.toByteArray(body.getContent())));
     assertEquals(1, json.getInt("count"));
     assertEquals(1, json.getInt("limit"));
-    assertEquals(ParseRequest.Method.GET.toString(), json.getString("_method"));
+    assertEquals(ParseHttpRequest.Method.GET.toString(), json.getString("_method"));
     // Verify body content-type is correct
     assertEquals("application/json", body.getContentType());
   }

--- a/Parse/src/test/java/com/parse/ParseRESTQueryCommandTest.java
+++ b/Parse/src/test/java/com/parse/ParseRESTQueryCommandTest.java
@@ -85,7 +85,7 @@ public class ParseRESTQueryCommandTest {
     ParseRESTQueryCommand command = ParseRESTQueryCommand.findCommand(state, "sessionToken");
 
     assertEquals("classes/TestObject", command.httpPath);
-    assertEquals(ParseRequest.Method.GET, command.method);
+    assertEquals(ParseHttpRequest.Method.GET, command.method);
     assertEquals("sessionToken", command.getSessionToken());
     Map<String, String> parameters = ParseRESTQueryCommand.encode(state, false);
     JSONObject jsonParameters = (JSONObject) NoObjectsEncoder.get().encode(parameters);
@@ -101,7 +101,7 @@ public class ParseRESTQueryCommandTest {
     ParseRESTQueryCommand command = ParseRESTQueryCommand.countCommand(state, "sessionToken");
 
     assertEquals("classes/TestObject", command.httpPath);
-    assertEquals(ParseRequest.Method.GET, command.method);
+    assertEquals(ParseHttpRequest.Method.GET, command.method);
     assertEquals("sessionToken", command.getSessionToken());
     Map<String, String> parameters = ParseRESTQueryCommand.encode(state, true);
     JSONObject jsonParameters = (JSONObject) NoObjectsEncoder.get().encode(parameters);

--- a/Parse/src/test/java/com/parse/ParseRESTUserCommandTest.java
+++ b/Parse/src/test/java/com/parse/ParseRESTUserCommandTest.java
@@ -42,7 +42,7 @@ public class ParseRESTUserCommandTest {
     ParseRESTUserCommand command = ParseRESTUserCommand.getCurrentUserCommand("sessionToken");
 
     assertEquals("users/me", command.httpPath);
-    assertEquals(ParseRequest.Method.GET, command.method);
+    assertEquals(ParseHttpRequest.Method.GET, command.method);
     assertNull(command.jsonParameters);
     assertEquals("sessionToken", command.getSessionToken());
     // TODO(mengyan): Find a way to verify revocableSession
@@ -54,7 +54,7 @@ public class ParseRESTUserCommandTest {
         "userName", "password", true);
 
     assertEquals("login", command.httpPath);
-    assertEquals(ParseRequest.Method.GET, command.method);
+    assertEquals(ParseHttpRequest.Method.GET, command.method);
     assertEquals("userName", command.jsonParameters.getString("username"));
     assertEquals("password", command.jsonParameters.getString("password"));
     assertNull(command.getSessionToken());
@@ -66,7 +66,7 @@ public class ParseRESTUserCommandTest {
     ParseRESTUserCommand command = ParseRESTUserCommand.resetPasswordResetCommand("test@parse.com");
 
     assertEquals("requestPasswordReset", command.httpPath);
-    assertEquals(ParseRequest.Method.POST, command.method);
+    assertEquals(ParseHttpRequest.Method.POST, command.method);
     assertEquals("test@parse.com", command.jsonParameters.getString("email"));
     assertNull(command.getSessionToken());
     // TODO(mengyan): Find a way to verify revocableSession
@@ -80,7 +80,7 @@ public class ParseRESTUserCommandTest {
         ParseRESTUserCommand.signUpUserCommand(parameters, "sessionToken", true);
 
     assertEquals("classes/_User", command.httpPath);
-    assertEquals(ParseRequest.Method.POST, command.method);
+    assertEquals(ParseHttpRequest.Method.POST, command.method);
     assertEquals("value", command.jsonParameters.getString("key"));
     assertEquals("sessionToken", command.getSessionToken());
     // TODO(mengyan): Find a way to verify revocableSession
@@ -94,7 +94,7 @@ public class ParseRESTUserCommandTest {
         ParseRESTUserCommand.serviceLogInUserCommand(parameters, "sessionToken", true);
 
     assertEquals("users", command.httpPath);
-    assertEquals(ParseRequest.Method.POST, command.method);
+    assertEquals(ParseHttpRequest.Method.POST, command.method);
     assertEquals("value", command.jsonParameters.getString("key"));
     assertEquals("sessionToken", command.getSessionToken());
     // TODO(mengyan): Find a way to verify revocableSession
@@ -108,7 +108,7 @@ public class ParseRESTUserCommandTest {
         ParseRESTUserCommand.serviceLogInUserCommand("facebook", facebookAuthData, true);
 
     assertEquals("users", command.httpPath);
-    assertEquals(ParseRequest.Method.POST, command.method);
+    assertEquals(ParseHttpRequest.Method.POST, command.method);
     assertNull(command.getSessionToken());
     JSONObject authenticationData = new JSONObject();
     authenticationData.put("facebook", PointerEncoder.get().encode(facebookAuthData));

--- a/Parse/src/test/java/com/parse/ParseRequestTest.java
+++ b/Parse/src/test/java/com/parse/ParseRequestTest.java
@@ -60,7 +60,7 @@ public class ParseRequestTest {
     ParseHttpClient mockHttpClient = mock(ParseHttpClient.class);
     when(mockHttpClient.execute(any(ParseHttpRequest.class))).thenThrow(new IOException());
 
-    TestParseRequest request = new TestParseRequest(ParseRequest.Method.GET, "http://parse.com");
+    TestParseRequest request = new TestParseRequest(ParseHttpRequest.Method.GET, "http://parse.com");
     Task<String> task = request.executeAsync(mockHttpClient);
     task.waitForCompletion();
 
@@ -78,7 +78,7 @@ public class ParseRequestTest {
     ParseHttpClient mockHttpClient = mock(ParseHttpClient.class);
     when(mockHttpClient.execute(any(ParseHttpRequest.class))).thenReturn(mockResponse);
 
-    ParseAWSRequest request = new ParseAWSRequest(ParseRequest.Method.GET, "localhost");
+    ParseAWSRequest request = new ParseAWSRequest(ParseHttpRequest.Method.GET, "localhost");
     TestProgressCallback downloadProgressCallback = new TestProgressCallback();
     Task<byte[]> task = request.executeAsync(mockHttpClient, null, downloadProgressCallback);
 
@@ -118,7 +118,7 @@ public class ParseRequestTest {
 
   private static class TestParseRequest extends ParseRequest<String> {
 
-    public TestParseRequest(Method method, String url) {
+    public TestParseRequest(ParseHttpRequest.Method method, String url) {
       super(method, url);
     }
 

--- a/Parse/src/test/java/com/parse/ParseURLConnectionHttpClientTest.java
+++ b/Parse/src/test/java/com/parse/ParseURLConnectionHttpClientTest.java
@@ -39,35 +39,35 @@ public class ParseURLConnectionHttpClientTest {
 
     // Get
     ParseHttpRequest parseRequest = builder
-        .setMethod(ParseRequest.Method.GET)
+        .setMethod(ParseHttpRequest.Method.GET)
         .setBody(null)
         .build();
     HttpURLConnection connection = parseClient.getRequest(parseRequest);
-    assertEquals(ParseRequest.Method.GET.toString(), connection.getRequestMethod());
+    assertEquals(ParseHttpRequest.Method.GET.toString(), connection.getRequestMethod());
 
     // Post
     parseRequest = builder
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody("test", "application/json"))
         .build();
     connection = parseClient.getRequest(parseRequest);
-    assertEquals(ParseRequest.Method.POST.toString(), connection.getRequestMethod());
+    assertEquals(ParseHttpRequest.Method.POST.toString(), connection.getRequestMethod());
 
     // Delete
     parseRequest = builder
-        .setMethod(ParseRequest.Method.DELETE)
+        .setMethod(ParseHttpRequest.Method.DELETE)
         .setBody(null)
         .build();
     connection = parseClient.getRequest(parseRequest);
-    assertEquals(ParseRequest.Method.DELETE.toString(), connection.getRequestMethod());
+    assertEquals(ParseHttpRequest.Method.DELETE.toString(), connection.getRequestMethod());
 
     // Put
     parseRequest = builder
-        .setMethod(ParseRequest.Method.PUT)
+        .setMethod(ParseHttpRequest.Method.PUT)
         .setBody(new ParseByteArrayHttpBody("test", "application/json"))
         .build();
     connection = parseClient.getRequest(parseRequest);
-    assertEquals(ParseRequest.Method.PUT.toString(), connection.getRequestMethod());
+    assertEquals(ParseHttpRequest.Method.PUT.toString(), connection.getRequestMethod());
   }
 
   @Test
@@ -82,7 +82,7 @@ public class ParseURLConnectionHttpClientTest {
     String contentType = "application/json";
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
         .setUrl(url)
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody(content, contentType))
         .setHeaders(headers)
         .build();
@@ -91,7 +91,7 @@ public class ParseURLConnectionHttpClientTest {
     HttpURLConnection connection = parseClient.getRequest(parseRequest);
 
     // Verify method
-    assertEquals(ParseRequest.Method.POST.toString(), connection.getRequestMethod());
+    assertEquals(ParseHttpRequest.Method.POST.toString(), connection.getRequestMethod());
     // Verify URL
     assertEquals(url, connection.getURL().toString());
     // Verify Headers
@@ -110,7 +110,7 @@ public class ParseURLConnectionHttpClientTest {
     String content = "test";
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
         .setUrl(url)
-        .setMethod(ParseRequest.Method.POST)
+        .setMethod(ParseHttpRequest.Method.POST)
         .setBody(new ParseByteArrayHttpBody(content, null))
         .build();
 


### PR DESCRIPTION
In order to public `ParseHttpRequest`, we need to public `Method` enum for http method.
One way is move `Method` enum from `ParseRequest` to `ParseHttpRequest`, but this involves lots of code changes.
The other way is to add `setMethodStr()` and `getMethodStr()` for `ParseHttpRequest`, this does not involve so many code changes, but make `ParseHttpRequest` looks ugly.
Any thoughts @grantland @hallucinogen ?