### PR TITLE
Clean ParseHttpRequset and ParseHttpResposne

### DIFF
--- a/Parse/src/main/java/com/parse/ParseDecompressInterceptor.java
+++ b/Parse/src/main/java/com/parse/ParseDecompressInterceptor.java
@@ -33,7 +33,7 @@ import java.util.zip.GZIPInputStream;
       // to -1
       newHeaders.put(CONTENT_LENGTH_HEADER, "-1");
       // TODO(mengyan): Add builder constructor based on an existing ParseHttpResponse
-      response = response.newBuilder()
+      response = new ParseHttpResponse.Builder(response)
           .setTotalSize(-1)
           .setHeaders(newHeaders)
           .setContent(new GZIPInputStream(response.getContent()))

--- a/Parse/src/main/java/com/parse/ParseHttpRequest.java
+++ b/Parse/src/main/java/com/parse/ParseHttpRequest.java
@@ -12,8 +12,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * The http request we send to parse server. Instances of this class are not immutable. The
+ * request body may be consumed only once. The other fields are immutable.
+ */
 /** package */ class ParseHttpRequest {
 
+  /**
+   * The {@link ParseHttpRequest} method type.
+   */
   public enum Method {
     GET, POST, PUT, DELETE;
 
@@ -61,43 +68,14 @@ import java.util.Map;
     }
   }
 
-  private final String url;
-  private final ParseHttpRequest.Method method;
-  private final Map<String, String> headers;
-  private final ParseHttpBody body;
-
-  protected ParseHttpRequest(Builder builder) {
-    this.url = builder.url;
-    this.method = builder.method;
-    this.headers = Collections.unmodifiableMap(new HashMap<>(builder.headers));
-    this.body = builder.body;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  public ParseHttpRequest.Method getMethod() {
-    return method;
-  }
-
-  public Map<String, String> getAllHeaders() {
-    return headers;
-  }
-
-  public String getHeader(String name) {
-    return headers.get(name);
-  }
-
-  public ParseHttpBody getBody() {
-    return body;
-  }
-
+  /**
+   * Builder of {@link ParseHttpRequest}.
+   */
   public static class Builder {
-    protected String url;
-    protected ParseHttpRequest.Method method;
-    protected Map<String, String> headers;
-    protected ParseHttpBody body;
+    private String url;
+    private Method method;
+    private Map<String, String> headers;
+    private ParseHttpBody body;
 
     public Builder() {
       this.headers = new HashMap<>();
@@ -130,13 +108,54 @@ import java.util.Map;
       return this;
     }
 
+    public Builder addHeaders(Map<String, String> headers) {
+      this.headers.putAll(headers);
+      return this;
+    }
+
     public Builder setHeaders(Map<String, String> headers) {
-      this.headers = headers;
+      this.headers = new HashMap<>(headers);
       return this;
     }
 
     public ParseHttpRequest build() {
       return new ParseHttpRequest(this);
     }
+  }
+
+  private final String url;
+  private final Method method;
+  private final Map<String, String> headers;
+  private final ParseHttpBody body;
+
+  private ParseHttpRequest(Builder builder) {
+    this.url = builder.url;
+    this.method = builder.method;
+    this.headers = Collections.unmodifiableMap(new HashMap<>(builder.headers));
+    this.body = builder.body;
+  }
+
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public Method getMethod() {
+    return method;
+  }
+
+  public Map<String, String> getAllHeaders() {
+    return headers;
+  }
+
+  public String getHeader(String name) {
+    return headers.get(name);
+  }
+
+  public ParseHttpBody getBody() {
+    return body;
   }
 }

--- a/Parse/src/main/java/com/parse/ParseHttpRequest.java
+++ b/Parse/src/main/java/com/parse/ParseHttpRequest.java
@@ -135,10 +135,6 @@ import java.util.Map;
     this.body = builder.body;
   }
 
-  public Builder newBuilder() {
-    return new Builder(this);
-  }
-
   public String getUrl() {
     return url;
   }

--- a/Parse/src/main/java/com/parse/ParseHttpRequest.java
+++ b/Parse/src/main/java/com/parse/ParseHttpRequest.java
@@ -19,7 +19,7 @@ import java.util.Map;
 /** package */ class ParseHttpRequest {
 
   /**
-   * The {@link ParseHttpRequest} method type.
+   * The {@code ParseHttpRequest} method type.
    */
   public enum Method {
     GET, POST, PUT, DELETE;
@@ -69,7 +69,7 @@ import java.util.Map;
   }
 
   /**
-   * Builder of {@link ParseHttpRequest}.
+   * Builder of {@code ParseHttpRequest}.
    */
   public static class Builder {
     private String url;

--- a/Parse/src/main/java/com/parse/ParseHttpResponse.java
+++ b/Parse/src/main/java/com/parse/ParseHttpResponse.java
@@ -130,18 +130,6 @@ import java.util.Map;
     this.contentType = builder.contentType;
   }
 
-  /**
-   * Generates a new {@link com.parse.ParseHttpResponse.Builder} based on an
-   * {@code ParseHttpResponse}, the {@link com.parse.ParseHttpResponse.Builder}'s values are come
-   * from the {@code ParseHttpResponse}.
-   *
-   * @return A new {@link com.parse.ParseHttpResponse.Builder} whose values are come from the
-   * {@code ParseHttpResponse}.
-   */
-  public Builder newBuilder() {
-    return new Builder(this);
-  }
-
   public int getStatusCode() {
     return statusCode;
   }

--- a/Parse/src/main/java/com/parse/ParseHttpResponse.java
+++ b/Parse/src/main/java/com/parse/ParseHttpResponse.java
@@ -14,11 +14,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * The base class of a http response we receive from parse server. It can be implemented by
- * different http library such as Apache http, Android URLConnection, Square OKHttp and so on.
+ * The http response we receive from parse server. Instances of this class are not immutable. The
+ * response body may be consumed only once. The other fields are immutable.
  */
 /** package */ class ParseHttpResponse {
 
+  /**
+   * Base builder for {@link ParseHttpResponse}.
+   */
   /* package */ static abstract class Init<T extends Init<T>> {
     private int statusCode;
     private InputStream content;
@@ -30,6 +33,7 @@ import java.util.Map;
     /* package */ abstract T self();
 
     public Init() {
+      this.totalSize = -1;
       this.headers = new HashMap<>();
     }
 
@@ -64,7 +68,7 @@ import java.util.Map;
     }
 
     public T addHeader(String key, String value) {
-      this.headers.put(key, value);
+      headers.put(key, value);
       return self();
     }
 
@@ -74,6 +78,9 @@ import java.util.Map;
     }
   }
 
+  /**
+   * Builder of {@link ParseHttpResponse}.
+   */
   public static class Builder extends Init<Builder> {
 
     @Override
@@ -81,11 +88,18 @@ import java.util.Map;
       return this;
     }
 
-    /* package */ Builder() {
+    public Builder() {
       super();
     }
 
-    /* package */ Builder(ParseHttpResponse response) {
+    /**
+     * Makes a new {@link ParseHttpResponse} {@code Builder} based on the input
+     * {@link ParseHttpResponse}.
+     *
+     * @param response
+     *          The {@link ParseHttpResponse} where the {@code Builder}'s values come from.
+     */
+    public Builder(ParseHttpResponse response) {
       super();
       this.setStatusCode(response.getStatusCode());
       this.setContent(response.getContent());
@@ -100,12 +114,12 @@ import java.util.Map;
     }
   }
 
-  /* package */ final int statusCode;
-  /* package */ final InputStream content;
-  /* package */ final long totalSize;
-  /* package */ final String reasonPhrase;
-  /* package */ final Map<String, String> headers;
-  /* package */ final String contentType;
+  private final int statusCode;
+  private final InputStream content;
+  private final long totalSize;
+  private final String reasonPhrase;
+  private final Map<String, String> headers;
+  private final String contentType;
 
   /* package */ ParseHttpResponse(Init<?> builder) {
     this.statusCode = builder.statusCode;
@@ -116,6 +130,14 @@ import java.util.Map;
     this.contentType = builder.contentType;
   }
 
+  /**
+   * Generates a new {@link com.parse.ParseHttpResponse.Builder} based on an
+   * {@link ParseHttpResponse}, the {@link com.parse.ParseHttpResponse.Builder}'s values are come
+   * from the {@link ParseHttpResponse}.
+   *
+   * @return A new {@link com.parse.ParseHttpResponse.Builder} whose values are come from the
+   * {@link ParseHttpResponse}.
+   */
   public Builder newBuilder() {
     return new Builder(this);
   }
@@ -124,10 +146,22 @@ import java.util.Map;
     return statusCode;
   }
 
+  /**
+   * Returns the content of the {@link ParseHttpResponse}'s body. The {@link InputStream} can only
+   * be read once and can't be reset.
+   *
+   * @return The {@link InputStream} of the {@link ParseHttpResponse}'s body.
+   */
   public InputStream getContent() {
     return content;
   }
 
+  /**
+   * Returns the size of the {@link ParseHttpResponse}'s body. -1 if the size of the
+   * {@link ParseHttpResponse}'s body is unknown.
+   *
+   * @return The size of the {@link ParseHttpResponse}'s body.
+   */
   public long getTotalSize() {
     return totalSize;
   }
@@ -141,7 +175,7 @@ import java.util.Map;
   }
 
   public String getHeader(String name) {
-    return headers == null ? null : headers.get(name);
+    return headers.get(name);
   }
 
   public Map<String, String> getAllHeaders() {

--- a/Parse/src/main/java/com/parse/ParseHttpResponse.java
+++ b/Parse/src/main/java/com/parse/ParseHttpResponse.java
@@ -20,7 +20,7 @@ import java.util.Map;
 /** package */ class ParseHttpResponse {
 
   /**
-   * Base builder for {@link ParseHttpResponse}.
+   * Base builder for {@code ParseHttpResponse}.
    */
   /* package */ static abstract class Init<T extends Init<T>> {
     private int statusCode;
@@ -79,7 +79,7 @@ import java.util.Map;
   }
 
   /**
-   * Builder of {@link ParseHttpResponse}.
+   * Builder of {@code ParseHttpResponse}.
    */
   public static class Builder extends Init<Builder> {
 
@@ -93,11 +93,11 @@ import java.util.Map;
     }
 
     /**
-     * Makes a new {@link ParseHttpResponse} {@code Builder} based on the input
-     * {@link ParseHttpResponse}.
+     * Makes a new {@code ParseHttpResponse} {@code Builder} based on the input
+     * {@code ParseHttpResponse}.
      *
      * @param response
-     *          The {@link ParseHttpResponse} where the {@code Builder}'s values come from.
+     *          The {@code ParseHttpResponse} where the {@code Builder}'s values come from.
      */
     public Builder(ParseHttpResponse response) {
       super();
@@ -132,11 +132,11 @@ import java.util.Map;
 
   /**
    * Generates a new {@link com.parse.ParseHttpResponse.Builder} based on an
-   * {@link ParseHttpResponse}, the {@link com.parse.ParseHttpResponse.Builder}'s values are come
-   * from the {@link ParseHttpResponse}.
+   * {@code ParseHttpResponse}, the {@link com.parse.ParseHttpResponse.Builder}'s values are come
+   * from the {@code ParseHttpResponse}.
    *
    * @return A new {@link com.parse.ParseHttpResponse.Builder} whose values are come from the
-   * {@link ParseHttpResponse}.
+   * {@code ParseHttpResponse}.
    */
   public Builder newBuilder() {
     return new Builder(this);
@@ -147,20 +147,20 @@ import java.util.Map;
   }
 
   /**
-   * Returns the content of the {@link ParseHttpResponse}'s body. The {@link InputStream} can only
+   * Returns the content of the {@code ParseHttpResponse}'s body. The {@link InputStream} can only
    * be read once and can't be reset.
    *
-   * @return The {@link InputStream} of the {@link ParseHttpResponse}'s body.
+   * @return The {@link InputStream} of the {@code ParseHttpResponse}'s body.
    */
   public InputStream getContent() {
     return content;
   }
 
   /**
-   * Returns the size of the {@link ParseHttpResponse}'s body. -1 if the size of the
-   * {@link ParseHttpResponse}'s body is unknown.
+   * Returns the size of the {@code ParseHttpResponse}'s body. -1 if the size of the
+   * {@code ParseHttpResponse}'s body is unknown.
    *
-   * @return The size of the {@link ParseHttpResponse}'s body.
+   * @return The size of the {@code ParseHttpResponse}'s body.
    */
   public long getTotalSize() {
     return totalSize;

--- a/Parse/src/main/java/com/parse/ParseLogInterceptor.java
+++ b/Parse/src/main/java/com/parse/ParseLogInterceptor.java
@@ -287,7 +287,7 @@ import bolts.Task;
       logResponseInfo(getLogger(), requestId, response, IGNORED_BODY_INFO);
     }
 
-    return response.newBuilder()
+    return new ParseHttpResponse.Builder(response)
         .setContent(newResponseBodyStream)
         .build();
   }

--- a/Parse/src/main/java/com/parse/ParseStethoInterceptor.java
+++ b/Parse/src/main/java/com/parse/ParseStethoInterceptor.java
@@ -276,7 +276,7 @@ import javax.annotation.Nullable;
           new DefaultResponseHandler(stethoEventReporter, requestId)
       );
       if (responseStream != null) {
-        response = response.newBuilder()
+        response = new ParseHttpResponse.Builder(response)
             .setContent(responseStream)
             .build();
       }

--- a/Parse/src/test/java/com/parse/ParseHttpRequestTest.java
+++ b/Parse/src/test/java/com/parse/ParseHttpRequestTest.java
@@ -104,7 +104,7 @@ public class ParseHttpRequestTest {
         .build();
 
     String newURL = "www.api.parse.com";
-    ParseHttpRequest newRequest = request.newBuilder()
+    ParseHttpRequest newRequest = new ParseHttpRequest.Builder(request)
         .setUrl(newURL)
         .build();
 

--- a/Parse/src/test/java/com/parse/ParseHttpRequestTest.java
+++ b/Parse/src/test/java/com/parse/ParseHttpRequestTest.java
@@ -10,6 +10,7 @@ package com.parse;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +18,7 @@ import java.util.Map;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class ParseHttpRequestTest {
@@ -77,6 +79,40 @@ public class ParseHttpRequestTest {
     assertEquals(1, requestAgain.getAllHeaders().size());
     assertEquals(value, requestAgain.getHeader(name));
     ParseHttpBody bodyAgain = requestAgain.getBody();
+    assertEquals(contentType, bodyAgain.getContentType());
+    assertArrayEquals(content.getBytes(), ParseIOUtils.toByteArray(body.getContent()));
+  }
+
+  @Test
+  public void testParseHttpRequestBuildWithParseHttpRequest() throws IOException {
+    String url = "www.parse.com";
+    ParseHttpRequest.Method method = ParseHttpRequest.Method.POST;
+    Map<String, String> headers = new HashMap<>();
+    String name = "name";
+    String value = "value";
+    headers.put(name, value);
+
+    String content = "content";
+    String contentType = "application/json";
+    ParseByteArrayHttpBody body = new ParseByteArrayHttpBody(content, contentType);
+
+    ParseHttpRequest request = new ParseHttpRequest.Builder()
+        .setUrl(url)
+        .addHeader(name, value)
+        .setMethod(method)
+        .setBody(body)
+        .build();
+
+    String newURL = "www.api.parse.com";
+    ParseHttpRequest newRequest = request.newBuilder()
+        .setUrl(newURL)
+        .build();
+
+    assertEquals(newURL, newRequest.getUrl());
+    assertEquals(method.toString(), newRequest.getMethod().toString());
+    assertEquals(1, newRequest.getAllHeaders().size());
+    assertEquals(value, newRequest.getHeader(name));
+    ParseHttpBody bodyAgain = newRequest.getBody();
     assertEquals(contentType, bodyAgain.getContentType());
     assertArrayEquals(content.getBytes(), ParseIOUtils.toByteArray(body.getContent()));
   }

--- a/Parse/src/test/java/com/parse/ParseHttpResponseTest.java
+++ b/Parse/src/test/java/com/parse/ParseHttpResponseTest.java
@@ -31,7 +31,7 @@ public class ParseHttpResponseTest {
     assertNull(response.getContentType());
     assertNull(response.getReasonPhrase());
     assertEquals(0, response.getStatusCode());
-    assertEquals(0, response.getTotalSize());
+    assertEquals(-1, response.getTotalSize());
     assertEquals(0, response.getAllHeaders().size());
     assertNull(response.getHeader("test"));
   }

--- a/Parse/src/test/java/com/parse/ParseHttpResponseTest.java
+++ b/Parse/src/test/java/com/parse/ParseHttpResponseTest.java
@@ -88,7 +88,7 @@ public class ParseHttpResponseTest {
         .build();
 
     String newReasonPhrase = "Failed";
-    ParseHttpResponse newResponse = response.newBuilder()
+    ParseHttpResponse newResponse = new ParseHttpResponse.Builder(response)
         .setReasonPhrase(newReasonPhrase)
         .build();
     


### PR DESCRIPTION
Clean `ParseHttpRequest` and `ParseHttpResponse` and add comment
For `Builder`
1. All constructor are public 
2. All fields are private
3. Add `addHeader()`, `addHeaders()` and `setHeaders()` helper methods
For `ParseHttpRequest` and `ParseHttpResponse`
1. All constructor are private
2. All fields are final and private
3. Add `newBuilder()` helper method
4. Header map is unmodifiable
