### PR TITLE
Split ParseNetworkInterceptor Module

### DIFF
--- a/Parse/src/main/java/com/parse/ParseNetworkInterceptor.java
+++ b/Parse/src/main/java/com/parse/ParseNetworkInterceptor.java
@@ -17,10 +17,14 @@ import java.io.IOException;
 /** package */ interface ParseNetworkInterceptor {
 
   /**
+   * Intercept the {@link ParseHttpRequest} with the help of
+   * {@link com.parse.ParseNetworkInterceptor.Chain}, proceed the {@link ParseHttpRequest} and get
+   * the {@link ParseHttpResponse}, intercept the {@link ParseHttpResponse} and return the
+   * intercepted {@link ParseHttpResponse}.
    * @param chain
-   *          The helper chain we used to get the request, proceed the request and receive the
-   *          response.
-   * @return The intercepted response.
+   *          The helper chain we used to get the {@link ParseHttpRequest}, proceed the
+   *          {@link ParseHttpRequest} and receive the {@link ParseHttpResponse}.
+   * @return The intercepted {@link ParseHttpResponse}.
    * @throws IOException
    */
   ParseHttpResponse intercept(Chain chain) throws IOException;

--- a/ParseNetworkLogger/build.gradle
+++ b/ParseNetworkLogger/build.gradle
@@ -1,0 +1,89 @@
+apply plugin: 'com.android.library'
+
+group = 'com.parse'
+version = VERSION_NAME
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName VERSION_NAME
+    }
+
+    lintOptions {
+        abortOnError false
+    }
+
+    buildTypes {
+        debug {
+            testCoverageEnabled = true
+        }
+    }
+}
+
+dependencies {
+    compile project(':Parse')
+
+    provided 'com.facebook.stetho:stetho:1.1.1'
+
+    testCompile 'junit:junit:4.12'
+    testCompile "org.json:json:20140107"
+}
+
+android.libraryVariants.all { variant ->
+    def name = variant.buildType.name
+    def jar = project.tasks.create(name: "jar${name.capitalize()}", type: Jar) {
+        dependsOn variant.javaCompile
+        from variant.javaCompile.destinationDir
+
+        manifest {
+            attributes(
+                    "Bundle-Name": 'parse-network-logger',
+                    "Bundle-Version": project.version
+            )
+        }
+
+        exclude '**/R.class'
+        exclude '**/R\$*.class'
+        exclude '**/Manifest.class'
+        exclude '**/Manifest\$*.class'
+        exclude '**/BuildConfig.class'
+    }
+
+    def javadoc = task("javadoc${variant.name.capitalize()}", type: Javadoc) {
+        description "Generates Javadoc for $variant.name."
+        source = variant.javaCompile.source
+        ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
+        classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+
+        options.docletpath = [rootProject.file("./gradle/ExcludeDoclet.jar")]
+        options.doclet = "me.grantland.doclet.ExcludeDoclet"
+
+        options.linksOffline("http://d.android.com/reference", "${android.sdkDirectory}/docs/reference")
+        options.links("http://boltsframework.github.io/docs/android/")
+
+        exclude '**/BuildConfig.java'
+        exclude '**/R.java'
+        exclude '**/internal/**'
+    }
+
+    def javadocJar = task("javadocJar${variant.name.capitalize()}", type: Jar, dependsOn: "javadoc${variant.name.capitalize()}") {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+    }
+
+    if (name.equals(com.android.builder.core.BuilderConstants.RELEASE)) {
+        artifacts.add('archives', jar);
+        artifacts.add('archives', javadocJar);
+    }
+}

--- a/ParseNetworkLogger/src/main/AndroidManifest.xml
+++ b/ParseNetworkLogger/src/main/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2015-present, Parse, LLC.
+  ~ All rights reserved.
+  ~
+  ~ This source code is licensed under the BSD-style license found in the
+  ~ LICENSE file in the root directory of this source tree. An additional grant
+  ~ of patent rights can be found in the PATENTS file in the same directory.
+  -->
+<manifest package="com.parse.networklogger">
+    <application />
+</manifest>

--- a/ParseNetworkLogger/src/main/java/com/parse/ParseLogInterceptor.java
+++ b/ParseNetworkLogger/src/main/java/com/parse/ParseLogInterceptor.java
@@ -31,7 +31,7 @@ import bolts.Task;
  * {@code ParseLogInterceptor} is used to log the request and response information to the given
  * logger.
  */
-/** package */ class ParseLogInterceptor implements ParseNetworkInterceptor {
+public class ParseLogInterceptor implements ParseNetworkInterceptor {
 
   private final static String TAG = "ParseLogNetworkInterceptor";
   private final static String LOG_PARAGRAPH_BREAKER = "--------------";

--- a/ParseNetworkLogger/src/main/java/com/parse/ParseStethoInterceptor.java
+++ b/ParseNetworkLogger/src/main/java/com/parse/ParseStethoInterceptor.java
@@ -225,6 +225,14 @@ public class ParseStethoInterceptor implements ParseNetworkInterceptor {
   // Request Id generator
   private final AtomicInteger nextRequestId = new AtomicInteger(0);
 
+  /**
+   * Intercept the {@link ParseHttpRequest} and {@link ParseHttpResponse}.
+   * @param chain
+   *          The helper chain we use to get the {@link ParseHttpRequest}, proceed the
+   *          {@link ParseHttpRequest} and receive the {@link ParseHttpResponse}.
+   * @return The intercepted {@link ParseHttpResponse}.
+   * @throws IOException
+   */
   @Override
   public ParseHttpResponse intercept(Chain chain) throws IOException {
     // Intercept request

--- a/ParseNetworkLogger/src/main/java/com/parse/ParseStethoInterceptor.java
+++ b/ParseNetworkLogger/src/main/java/com/parse/ParseStethoInterceptor.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
  * {@code ParseStethoInterceptor} is used to log the request and response through Stetho to chrome
  * browser debugger.
  */
-/** package */ class ParseStethoInterceptor implements ParseNetworkInterceptor {
+public class ParseStethoInterceptor implements ParseNetworkInterceptor {
 
   private static final String CONTENT_LENGTH_HEADER = "Content-Length";
   private static final String CONTENT_TYPE_HEADER = "Content-Type";

--- a/ParseNetworkLogger/src/test/java/com/parse/ParseLogInterceptorTest.java
+++ b/ParseNetworkLogger/src/test/java/com/parse/ParseLogInterceptorTest.java
@@ -11,9 +11,6 @@ package com.parse;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -26,9 +23,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-// For GZIPOutputStream
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 21)
 public class ParseLogInterceptorTest {
 
   @Rule

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 include ':Parse'
 include ':ParseStarterProject'
-
+include ':ParseNetworkLogger'


### PR DESCRIPTION
Still can not solve the wired robolectric Manifest bug, right now since this test does not heavily rely on the android framework methods, so I manually import json library and remove robolectric dependency. I will try to make a sample project and file the bug to robolectric. Even we can avoid robolectric this time, when we want to modularization in the future, we have to find a solution. @grantland 