### PR TITLE
Create cache dir if it does not exist before we use tempFile

### DIFF
--- a/Parse/src/main/java/com/parse/ParseAWSRequest.java
+++ b/Parse/src/main/java/com/parse/ParseAWSRequest.java
@@ -56,7 +56,7 @@ import bolts.Task;
         InputStream responseStream = null;
         try {
           responseStream = response.getContent();
-          FileOutputStream tempFileStream = new FileOutputStream(tempFile);
+          FileOutputStream tempFileStream = ParseFileUtils.openOutputStream(tempFile);
 
           int nRead;
           byte[] data = new byte[32 << 10]; // 32KB

--- a/Parse/src/test/java/com/parse/ParseFileControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParseFileControllerTest.java
@@ -303,32 +303,6 @@ public class ParseFileControllerTest {
 
     ParseHttpClient awsClient = mock(ParseHttpClient.class);
     when(awsClient.execute(any(ParseHttpRequest.class))).thenReturn(mockResponse);
-    File root = temporaryFolder.getRoot();
-    ParseFileController controller = new ParseFileController(null, root).awsClient(awsClient);
-
-    ParseFile.State state = new ParseFile.State.Builder()
-        .name("file_name")
-        .url("url")
-        .build();
-    Task<File> task = controller.fetchAsync(state, null, null, null);
-    File result = ParseTaskUtils.wait(task);
-
-    verify(awsClient, times(1)).execute(any(ParseHttpRequest.class));
-    assertTrue(result.exists());
-    assertEquals("hello", ParseFileUtils.readFileToString(result, "UTF-8"));
-    assertFalse(controller.getTempFile(state).exists());
-  }
-
-  @Test
-  public void testFetchAsyncSuccessWithCacheDirNotExist() throws Exception {
-    byte[] data = "hello".getBytes();
-    ParseHttpResponse response = mock(ParseHttpResponse.class);
-    when(response.getStatusCode()).thenReturn(200);
-    when(response.getContent()).thenReturn(new ByteArrayInputStream(data));
-    when(response.getTotalSize()).thenReturn((long) data.length);
-
-    ParseHttpClient awsClient = mock(ParseHttpClient.class);
-    when(awsClient.execute(any(ParseHttpRequest.class))).thenReturn(response);
     // Make sure cache dir does not exist
     File root = new File(temporaryFolder.getRoot(), "cache");
     assertFalse(root.exists());


### PR DESCRIPTION
Fix a bug in ParseAWSRequest, if users never download/upload any `ParseFile`, the cache dir does not exist. In this situation, if users download a `ParseFile`, in `ParseAWSRequset`, `new FileOutputStream(tempFile)` will throw an exception since parent dir does not exist. By using `ParseFileUtils`, we create parent dir if it does not exist which fixes this problem.