### PR TITLE
Remove ParseRequest defaultClient

### DIFF
--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -193,7 +193,6 @@ public class Parse {
 
     ParseHttpClient.setKeepAlive(true);
     ParseHttpClient.setMaxConnections(20);
-    ParseRequest.setDefaultClient(ParsePlugins.get().restClient());
     // If we have interceptors in list, we have to initialize all http clients and add interceptors
     if (interceptors != null) {
       initializeParseHttpClientsWithParseNetworkInterceptors();
@@ -414,15 +413,16 @@ public class Parse {
           || (isLocalDatastoreEnabled && eventuallyQueue instanceof ParseCommandCache)
           || (!isLocalDatastoreEnabled && eventuallyQueue instanceof ParsePinningEventuallyQueue)) {
         checkContext();
+        ParseHttpClient httpClient = ParsePlugins.get().restClient();
         eventuallyQueue = isLocalDatastoreEnabled
-          ? new ParsePinningEventuallyQueue(context)
-          : new ParseCommandCache(context);
+          ? new ParsePinningEventuallyQueue(context, httpClient)
+          : new ParseCommandCache(context, httpClient);
 
         // We still need to clear out the old command cache even if we're using Pinning in case
         // anything is left over when the user upgraded. Checking number of pending and then
         // initializing should be enough.
         if (isLocalDatastoreEnabled && ParseCommandCache.getPendingCount() > 0) {
-          new ParseCommandCache(context);
+          new ParseCommandCache(context, httpClient);
         }
       }
       return eventuallyQueue;

--- a/Parse/src/main/java/com/parse/ParseCommandCache.java
+++ b/Parse/src/main/java/com/parse/ParseCommandCache.java
@@ -90,6 +90,8 @@ import bolts.Task;
 
   private Logger log; // Why is there a custom logger? To prevent Mockito deadlock!
 
+  private final ParseHttpClient httpClient;
+
   ConnectivityNotifier notifier;
   ConnectivityNotifier.ConnectivityListener listener = new ConnectivityNotifier.ConnectivityListener() {
     @Override
@@ -121,12 +123,14 @@ import bolts.Task;
     }
   };
 
-  public ParseCommandCache(Context context) {
+  public ParseCommandCache(Context context, ParseHttpClient client) {
     setConnected(false);
+
     shouldStop = false;
     running = false;
 
     runningLock = new Object();
+    httpClient = client;
 
     log = Logger.getLogger(TAG);
 
@@ -526,7 +530,7 @@ import bolts.Task;
             }
             notifyTestHelper(TestHelper.COMMAND_OLD_FORMAT_DISCARDED);
           } else {
-            commandTask = command.executeAsync().continueWithTask(new Continuation<JSONObject, Task<JSONObject>>() {
+            commandTask = command.executeAsync(httpClient).continueWithTask(new Continuation<JSONObject, Task<JSONObject>>() {
               @Override
               public Task<JSONObject> then(Task<JSONObject> task) throws Exception {
                 String localId = command.getLocalId();

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -1660,11 +1660,13 @@ public class ParseObject {
 
   // Currently only used by ParsePinningEventuallyQueue for saveEventually due to the limitation in
   // ParseCommandCache that it can only return JSONObject result.
-  /* package */ Task<JSONObject> saveAsync(final ParseOperationSet operationSet, String sessionToken)
-      throws ParseException {
+  /* package */ Task<JSONObject> saveAsync(
+      ParseHttpClient client,
+      final ParseOperationSet operationSet,
+      String sessionToken) throws ParseException {
     final ParseRESTCommand command =
         currentSaveEventuallyCommand(operationSet, PointerEncoder.get(), sessionToken);
-    return command.executeAsync();
+    return command.executeAsync(client);
   }
 
   /**

--- a/Parse/src/main/java/com/parse/ParseRequest.java
+++ b/Parse/src/main/java/com/parse/ParseRequest.java
@@ -70,21 +70,6 @@ import bolts.Task;
 
   private static long defaultInitialRetryDelay = DEFAULT_INITIAL_RETRY_DELAY;
 
-  // TODO(grantland): Remove once we're able to inject a http client into all of our controllers
-  // and we don't need this for mocking anymore.
-  private static ParseHttpClient defaultClient = null;
-  @Deprecated
-  public static void setDefaultClient(ParseHttpClient client) {
-    defaultClient = client;
-  }
-  @Deprecated
-  public static ParseHttpClient getDefaultClient() {
-    if (defaultClient == null) {
-      throw new IllegalStateException("Can't send Parse HTTPS request before Parse.initialize()");
-    }
-    return defaultClient;
-  }
-
   public static void setDefaultInitialRetryDelay(long delay) {
     defaultInitialRetryDelay = delay;
   }
@@ -166,23 +151,6 @@ import bolts.Task;
 
   protected abstract Task<Response> onResponseAsync(ParseHttpResponse response,
       ProgressCallback downloadProgressCallback);
-
-  @Deprecated
-  public Task<Response> executeAsync() {
-    return executeAsync(getDefaultClient());
-  }
-
-  @Deprecated
-  public Task<Response> executeAsync(
-      ProgressCallback uploadProgressCallback,
-      ProgressCallback downloadProgressCallback,
-      Task<Void> cancellationToken) {
-    return executeAsync(
-        getDefaultClient(),
-        uploadProgressCallback,
-        downloadProgressCallback,
-        cancellationToken);
-  }
 
   /*
    * Starts retrying the block.


### PR DESCRIPTION
We do not need defaultClient as a global state in class ParseRequest anymore.