### PR TITLE
Update proguard-rules.pro for android-23

### DIFF
--- a/ParseStarterProject/proguard-rules.pro
+++ b/ParseStarterProject/proguard-rules.pro
@@ -23,5 +23,7 @@
 # Required for Parse
 -keepattributes *Annotation*
 -keepattributes Signature
+-dontwarn android.net.SSLCertificateSocketFactory
+-dontwarn android.app.Notification
 -dontwarn com.squareup.**
 -dontwarn okio.**


### PR DESCRIPTION
android-23 removed some APIs that our SDK uses internally. Luckily,
we only conditionally use these APIs on older devices so this is
a non-issue for our SDK running on android-23.

This change adds instructions to ignore warnings from proguard stating
that these APIs do not exist when using `compileSdkVersion = 23` since
we already have checks in place.

Test Plan:

Change ParseStarterProject's `build.gradle`:

```
android {
    compileSdkVersion 23
    useLibrary `org.apache.http.legacy`

    // ...

    buildTypes {
        release {
            minifyEnabled true

            // ...
        }
    }
}
```

Resolves #231 