### PR TITLE
Decouple object subclassing.

### DIFF
--- a/Parse/src/main/java/com/parse/FileObjectStore.java
+++ b/Parse/src/main/java/com/parse/FileObjectStore.java
@@ -19,6 +19,10 @@ import bolts.Task;
 
 /** package */ class FileObjectStore<T extends ParseObject> implements ParseObjectStore<T> {
 
+  private static ParseObjectSubclassingController getSubclassingController() {
+    return ParseCorePlugins.getInstance().getSubclassingController();
+  }
+
   /**
    * Saves the {@code ParseObject} to the a file on disk as JSON in /2/ format.
    *
@@ -75,7 +79,7 @@ import bolts.Task;
   private final ParseObjectCurrentCoder coder;
 
   public FileObjectStore(Class<T> clazz, File file, ParseObjectCurrentCoder coder) {
-    this(ParseObject.getClassName(clazz), file, coder);
+    this(getSubclassingController().getClassName(clazz), file, coder);
   }
 
   public FileObjectStore(String className, File file, ParseObjectCurrentCoder coder) {

--- a/Parse/src/main/java/com/parse/OfflineObjectStore.java
+++ b/Parse/src/main/java/com/parse/OfflineObjectStore.java
@@ -16,6 +16,10 @@ import bolts.Task;
 
 /** package */ class OfflineObjectStore<T extends ParseObject> implements ParseObjectStore<T> {
 
+  private static ParseObjectSubclassingController getSubclassingController() {
+    return ParseCorePlugins.getInstance().getSubclassingController();
+  }
+
   private static <T extends ParseObject> Task<T> migrate(
       final ParseObjectStore<T> from, final ParseObjectStore<T> to) {
     return from.getAsync().onSuccessTask(new Continuation<T, Task<T>>() {
@@ -44,7 +48,7 @@ import bolts.Task;
   private final ParseObjectStore<T> legacy;
 
   public OfflineObjectStore(Class<T> clazz, String pinName, ParseObjectStore<T> legacy) {
-    this(ParseObject.getClassName(clazz), pinName, legacy);
+    this(getSubclassingController().getClassName(clazz), pinName, legacy);
   }
 
   public OfflineObjectStore(String className, String pinName, ParseObjectStore<T> legacy) {

--- a/Parse/src/main/java/com/parse/ParseCorePlugins.java
+++ b/Parse/src/main/java/com/parse/ParseCorePlugins.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
   private AtomicReference<ParseDefaultACLController> defaultACLController = new AtomicReference<>();
 
   private AtomicReference<LocalIdManager> localIdManager = new AtomicReference<>();
+  private AtomicReference<ParseObjectSubclassingController> subclassingController = new AtomicReference<>();
 
   private ParseCorePlugins() {
     // do nothing
@@ -334,6 +335,21 @@ import java.util.concurrent.atomic.AtomicReference;
     if (!localIdManager.compareAndSet(null, manager)) {
       throw new IllegalStateException(
           "Another localId manager was already registered: " + localIdManager.get());
+    }
+  }
+
+  public ParseObjectSubclassingController getSubclassingController() {
+    if (subclassingController.get() == null) {
+      ParseObjectSubclassingController controller = new ParseObjectSubclassingController();
+      subclassingController.compareAndSet(null, controller);
+    }
+    return subclassingController.get();
+  }
+
+  public void registerSubclassingController(ParseObjectSubclassingController controller) {
+    if (!subclassingController.compareAndSet(null, controller)) {
+      throw new IllegalStateException(
+          "Another subclassing controller was already registered: " + subclassingController.get());
     }
   }
 }

--- a/Parse/src/main/java/com/parse/ParseObjectSubclassingController.java
+++ b/Parse/src/main/java/com/parse/ParseObjectSubclassingController.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+package com.parse;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+/* package */ class ParseObjectSubclassingController {
+  private static class ObjectSubclassInfo {
+    public final Class<? extends ParseObject> type;
+    public final Constructor<? extends ParseObject> constructor;
+
+    public ObjectSubclassInfo(Class<? extends ParseObject> clazz) throws NoSuchMethodException, IllegalAccessException {
+      type = clazz;
+      constructor = getConstructor(clazz);
+    }
+
+    private static Constructor<? extends ParseObject> getConstructor(Class<? extends  ParseObject> clazz) throws NoSuchMethodException, IllegalAccessException {
+      Constructor<? extends ParseObject> constructor = clazz.getDeclaredConstructor();
+      if (constructor == null) {
+        throw new NoSuchMethodException();
+      }
+      int modifiers = constructor.getModifiers();
+      if (Modifier.isPublic(modifiers) || (clazz.getPackage().getName().equals("com.parse") &&
+          !(Modifier.isProtected(modifiers) || Modifier.isPrivate(modifiers)))) {
+        return constructor;
+      }
+      throw new IllegalAccessException();
+    }
+  }
+
+  private final Object mutex = new Object();
+  private final Map<String, ObjectSubclassInfo> registeredSubclasses = new HashMap<>();
+
+  /* package */ String getClassName(Class<? extends ParseObject> clazz) {
+    ParseClassName info = clazz.getAnnotation(ParseClassName.class);
+    if (info == null) {
+      throw new IllegalArgumentException("No ParseClassName annotation provided on " + clazz);
+    }
+    return info.value();
+  }
+
+  /* package */ boolean isSubclassValid(String className, Class<? extends ParseObject> clazz) {
+    ObjectSubclassInfo info = null;
+
+    synchronized (mutex) {
+      info = registeredSubclasses.get(className);
+    }
+
+    return info == null
+      ? clazz == ParseObject.class
+      : info.type == clazz;
+  }
+
+  /* package */ void registerSubclass(Class<? extends ParseObject> clazz) {
+    if (!ParseObject.class.isAssignableFrom(clazz)) {
+      throw new IllegalArgumentException("Cannot register a type that is not a subclass of ParseObject");
+    }
+
+    String className = getClassName(clazz);
+    ObjectSubclassInfo previousInfo = null;
+
+    synchronized (mutex) {
+      previousInfo = registeredSubclasses.get(className);
+      if (previousInfo != null) {
+        if (clazz.isAssignableFrom(previousInfo.type)) {
+          // Previous subclass is more specific or equal to the current type, do nothing.
+          return;
+        } else if (previousInfo.type.isAssignableFrom(clazz)) {
+          // Previous subclass is parent of new child subclass, fallthrough and actually
+          // register this class.
+          /* Do nothing */
+        } else {
+          throw new IllegalArgumentException(
+            "Tried to register both " + previousInfo.type.getName() + " and " +
+             clazz.getName() + " as the ParseObject subclass of " + className + ". " +
+             "Cannot determine the right class to use because netiher inherits from the other."
+          );
+        }
+      }
+
+      try {
+        registeredSubclasses.put(className, new ObjectSubclassInfo(clazz));
+      } catch (NoSuchMethodException ex) {
+        throw new IllegalArgumentException(
+          "Cannot register a type that does not implement the default constructor!"
+        );
+      } catch (IllegalAccessException ex) {
+        throw new IllegalArgumentException(
+          "Default constructor for " + clazz + " is not accessible."
+        );
+      }
+    }
+
+    if (previousInfo != null) {
+      // TODO: This is super tightly coupled. Let's remove it when automatic registration is in.
+      // NOTE: Perform this outside of the mutex, to prevent any potential deadlocks.
+      if (className.equals(getClassName(ParseUser.class))) {
+        ParseUser.getCurrentUserController().clearFromMemory();
+      } else if (className.equals(getClassName(ParseInstallation.class))) {
+        ParseInstallation.getCurrentInstallationController().clearFromMemory();
+      }
+    }
+  }
+
+  /* package */ void unregisterSubclass(Class<? extends ParseObject> clazz) {
+    String className = getClassName(clazz);
+
+    synchronized (mutex) {
+      registeredSubclasses.remove(className);
+    }
+  }
+
+  /* package */ ParseObject newInstance(String className) {
+    ObjectSubclassInfo info = null;
+
+    synchronized (mutex) {
+      info = registeredSubclasses.get(className);
+    }
+
+    try {
+      return info != null
+        ? info.constructor.newInstance()
+        : new ParseObject(className);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create instance of subclass.", e);
+    }
+  }
+}

--- a/Parse/src/main/java/com/parse/ParseObjectSubclassingController.java
+++ b/Parse/src/main/java/com/parse/ParseObjectSubclassingController.java
@@ -14,31 +14,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /* package */ class ParseObjectSubclassingController {
-  private static class ObjectSubclassInfo {
-    public final Class<? extends ParseObject> type;
-    public final Constructor<? extends ParseObject> constructor;
-
-    public ObjectSubclassInfo(Class<? extends ParseObject> clazz) throws NoSuchMethodException, IllegalAccessException {
-      type = clazz;
-      constructor = getConstructor(clazz);
-    }
-
-    private static Constructor<? extends ParseObject> getConstructor(Class<? extends  ParseObject> clazz) throws NoSuchMethodException, IllegalAccessException {
-      Constructor<? extends ParseObject> constructor = clazz.getDeclaredConstructor();
-      if (constructor == null) {
-        throw new NoSuchMethodException();
-      }
-      int modifiers = constructor.getModifiers();
-      if (Modifier.isPublic(modifiers) || (clazz.getPackage().getName().equals("com.parse") &&
-          !(Modifier.isProtected(modifiers) || Modifier.isPrivate(modifiers)))) {
-        return constructor;
-      }
-      throw new IllegalAccessException();
-    }
-  }
-
   private final Object mutex = new Object();
-  private final Map<String, ObjectSubclassInfo> registeredSubclasses = new HashMap<>();
+  private final Map<String, Constructor<? extends ParseObject>> registeredSubclasses = new HashMap<>();
 
   /* package */ String getClassName(Class<? extends ParseObject> clazz) {
     ParseClassName info = clazz.getAnnotation(ParseClassName.class);
@@ -49,15 +26,15 @@ import java.util.Map;
   }
 
   /* package */ boolean isSubclassValid(String className, Class<? extends ParseObject> clazz) {
-    ObjectSubclassInfo info = null;
+    Constructor<? extends ParseObject> constructor = null;
 
     synchronized (mutex) {
-      info = registeredSubclasses.get(className);
+      constructor = registeredSubclasses.get(className);
     }
 
-    return info == null
+    return constructor == null
       ? clazz == ParseObject.class
-      : info.type == clazz;
+      : constructor.getDeclaringClass() == clazz;
   }
 
   /* package */ void registerSubclass(Class<? extends ParseObject> clazz) {
@@ -66,29 +43,30 @@ import java.util.Map;
     }
 
     String className = getClassName(clazz);
-    ObjectSubclassInfo previousInfo = null;
+    Constructor<? extends ParseObject> previousConstructor = null;
 
     synchronized (mutex) {
-      previousInfo = registeredSubclasses.get(className);
-      if (previousInfo != null) {
-        if (clazz.isAssignableFrom(previousInfo.type)) {
+      previousConstructor = registeredSubclasses.get(className);
+      if (previousConstructor != null) {
+        Class<? extends ParseObject> previousClass = previousConstructor.getDeclaringClass();
+        if (clazz.isAssignableFrom(previousClass)) {
           // Previous subclass is more specific or equal to the current type, do nothing.
           return;
-        } else if (previousInfo.type.isAssignableFrom(clazz)) {
+        } else if (previousClass.isAssignableFrom(clazz)) {
           // Previous subclass is parent of new child subclass, fallthrough and actually
           // register this class.
           /* Do nothing */
         } else {
           throw new IllegalArgumentException(
-            "Tried to register both " + previousInfo.type.getName() + " and " +
-             clazz.getName() + " as the ParseObject subclass of " + className + ". " +
-             "Cannot determine the right class to use because netiher inherits from the other."
+            "Tried to register both " + previousClass.getName() + " and " + clazz.getName() +
+            " as the ParseObject subclass of " + className + ". " + "Cannot determine the right " +
+            "class to use because neither inherits from the other."
           );
         }
       }
 
       try {
-        registeredSubclasses.put(className, new ObjectSubclassInfo(clazz));
+        registeredSubclasses.put(className, getConstructor(clazz));
       } catch (NoSuchMethodException ex) {
         throw new IllegalArgumentException(
           "Cannot register a type that does not implement the default constructor!"
@@ -100,7 +78,7 @@ import java.util.Map;
       }
     }
 
-    if (previousInfo != null) {
+    if (previousConstructor != null) {
       // TODO: This is super tightly coupled. Let's remove it when automatic registration is in.
       // NOTE: Perform this outside of the mutex, to prevent any potential deadlocks.
       if (className.equals(getClassName(ParseUser.class))) {
@@ -120,20 +98,33 @@ import java.util.Map;
   }
 
   /* package */ ParseObject newInstance(String className) {
-    ObjectSubclassInfo info = null;
+    Constructor<? extends ParseObject> constructor = null;
 
     synchronized (mutex) {
-      info = registeredSubclasses.get(className);
+      constructor = registeredSubclasses.get(className);
     }
 
     try {
-      return info != null
-        ? info.constructor.newInstance()
+      return constructor != null
+        ? constructor.newInstance()
         : new ParseObject(className);
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new RuntimeException("Failed to create instance of subclass.", e);
     }
+  }
+
+  private static Constructor<? extends ParseObject> getConstructor(Class<? extends  ParseObject> clazz) throws NoSuchMethodException, IllegalAccessException {
+    Constructor<? extends ParseObject> constructor = clazz.getDeclaredConstructor();
+    if (constructor == null) {
+      throw new NoSuchMethodException();
+    }
+    int modifiers = constructor.getModifiers();
+    if (Modifier.isPublic(modifiers) || (clazz.getPackage().getName().equals("com.parse") &&
+      !(Modifier.isProtected(modifiers) || Modifier.isPrivate(modifiers)))) {
+      return constructor;
+    }
+    throw new IllegalAccessException();
   }
 }

--- a/Parse/src/main/java/com/parse/ParsePush.java
+++ b/Parse/src/main/java/com/parse/ParsePush.java
@@ -37,6 +37,10 @@ public class ParsePush {
     return ParseCorePlugins.getInstance().getPushChannelsController();
   }
 
+  private static ParseObjectSubclassingController getSubclassingController() {
+    return ParseCorePlugins.getInstance().getSubclassingController();
+  }
+
   private static void checkArgument(boolean expression, Object errorMessage) {
     if (!expression) {
       throw new IllegalArgumentException(String.valueOf(errorMessage));
@@ -126,7 +130,8 @@ public class ParsePush {
         checkArgument(pushToIOS == null && pushToAndroid == null, "Cannot set push targets " +
             "(i.e. setPushToAndroid or setPushToIOS) when pushing to a query");
         checkArgument(
-            query.getClassName().equals(ParseObject.getClassName(ParseInstallation.class)),
+            query.getClassName().equals(
+                getSubclassingController().getClassName(ParseInstallation.class)),
             "Can only push to a query for Installations");
         channelSet = null;
         this.query = query;

--- a/Parse/src/main/java/com/parse/ParseQuery.java
+++ b/Parse/src/main/java/com/parse/ParseQuery.java
@@ -92,6 +92,10 @@ public class ParseQuery<T extends ParseObject> {
     return ParseCorePlugins.getInstance().getQueryController();
   }
 
+  private static ParseObjectSubclassingController getSubclassingController() {
+    return ParseCorePlugins.getInstance().getSubclassingController();
+  }
+
   /**
    * Constraints for a {@code ParseQuery}'s where clause. A map of field names to constraints. The
    * values can either be actual values to compare with for equality, or instances of
@@ -361,7 +365,7 @@ public class ParseQuery<T extends ParseObject> {
       }
 
       public Builder(Class<T> subclass) {
-        this(ParseObject.getClassName(subclass));
+        this(getSubclassingController().getClassName(subclass));
       }
 
       public Builder(State state) {
@@ -896,7 +900,7 @@ public class ParseQuery<T extends ParseObject> {
    *          The {@link ParseObject} subclass type to retrieve.
    */
   public ParseQuery(Class<T> subclass) {
-    this(ParseObject.getClassName(subclass));
+    this(getSubclassingController().getClassName(subclass));
   }
 
   /**

--- a/Parse/src/test/java/com/parse/ParseRoleTest.java
+++ b/Parse/src/test/java/com/parse/ParseRoleTest.java
@@ -8,6 +8,8 @@
  */
 package com.parse;
 
+import com.parse.ParseCorePlugins;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -155,7 +157,7 @@ public class ParseRoleTest {
   public void testGetQuery() {
     ParseQuery query = ParseRole.getQuery();
 
-    assertEquals(ParseObject.getClassName(ParseRole.class), query.getBuilder().getClassName());
+    assertEquals(ParseCorePlugins.getInstance().getSubclassingController().getClassName(ParseRole.class), query.getBuilder().getClassName());
   }
 
   //endregion

--- a/Parse/src/test/java/com/parse/ParseRoleTest.java
+++ b/Parse/src/test/java/com/parse/ParseRoleTest.java
@@ -155,7 +155,7 @@ public class ParseRoleTest {
 
   @Test
   public void testGetQuery() {
-    ParseQuery query = ParseRole.getQuery();
+    ParseQuery<?> query = ParseRole.getQuery();
 
     assertEquals(ParseCorePlugins.getInstance().getSubclassingController().getClassName(ParseRole.class), query.getBuilder().getClassName());
   }

--- a/Parse/src/test/java/com/parse/SubclassTest.java
+++ b/Parse/src/test/java/com/parse/SubclassTest.java
@@ -12,6 +12,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.IllegalArgumentException;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -85,8 +87,8 @@ public class SubclassTest {
   @After
   public void tearDown() throws Exception {
     ParseObject.unregisterParseSubclasses();
-    ParseObject.unregisterSubclass("Person");
-    ParseObject.unregisterSubclass("ClassWithDirtyingConstructor");
+    ParseObject.unregisterSubclass(Person.class);
+    ParseObject.unregisterSubclass(ClassWithDirtyingConstructor.class);
   }
 
   @SuppressWarnings("unused")
@@ -102,7 +104,7 @@ public class SubclassTest {
     try {
       new UnregisteredClass();
     } finally {
-      ParseObject.unregisterSubclass("UnregisteredClass");
+      ParseObject.unregisterSubclass(UnregisteredClass.class);
     }
   }
 
@@ -137,10 +139,18 @@ public class SubclassTest {
       assertEquals(MyUser.class, ParseObject.create("_User").getClass());
       ParseObject.registerSubclass(ParseUser.class);
       assertEquals(MyUser.class, ParseObject.create("_User").getClass());
-      ParseObject.registerSubclass(MyUser2.class);
-      assertEquals(MyUser2.class, ParseObject.create("_User").getClass());
+
+      // This is expected to fail as MyUser2 and MyUser are not directly related.
+      try {
+        ParseObject.registerSubclass(MyUser2.class);
+        fail();
+      } catch (IllegalArgumentException ex) {
+        /* expected */
+      }
+
+      assertEquals(MyUser.class, ParseObject.create("_User").getClass());
     } finally {
-      ParseObject.unregisterSubclass("_User");
+      ParseObject.unregisterSubclass(ParseUser.class);
       ParseCorePlugins.getInstance().reset();
     }
   }


### PR DESCRIPTION
This fully decouples object subclassing from the ParseObject class, bringing it up to parity with our other native platforms.