### PR TITLE
Add more log for push

### DIFF
--- a/Parse/src/main/java/com/parse/GcmRegistrar.java
+++ b/Parse/src/main/java/com/parse/GcmRegistrar.java
@@ -182,6 +182,8 @@ import bolts.Task;
     String registrationId = intent.getStringExtra(REGISTRATION_ID_EXTRA);
 
     if (registrationId != null && registrationId.length() > 0) {
+      PLog.v(TAG, "Received deviceToken <" + registrationId + "> from GCM.");
+
       ParseInstallation installation = ParseInstallation.getCurrentInstallation();
       // Compare the new deviceToken with the old deviceToken, we only update the
       // deviceToken if the new one is different from the old one. This does not follow google

--- a/Parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
+++ b/Parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
@@ -141,6 +141,7 @@ public class ParsePushBroadcastReceiver extends BroadcastReceiver {
       PLog.e(TAG, "Can not get push data from intent.");
       return;
     }
+    PLog.v(TAG, "Received push data: " + pushDataStr);
 
     JSONObject pushData = null;
     try {


### PR DESCRIPTION
1. Add log when we recive deviceToken from GCM.
2. Add log when developers try to use PPNS but miss something.
3. Add log to recommend developers to use GCM