### PR TITLE
Fix NPE

### DIFF
--- a/Parse/src/main/java/com/parse/ParseKeyValueCache.java
+++ b/Parse/src/main/java/com/parse/ParseKeyValueCache.java
@@ -64,7 +64,7 @@ import java.util.Date;
   }
 
   private static File getKeyValueCacheDir() {
-    if (directory == null || !directory.exists()) {
+    if (directory != null && !directory.exists()) {
       directory.mkdir();
     }
     return directory;


### PR DESCRIPTION
If `directory == null`, we'll NPE on `directory.mkdir()`.