### PR TITLE
Allow the system to error when missing required permissions

### DIFF
--- a/Parse/src/main/java/com/parse/ManifestInfo.java
+++ b/Parse/src/main/java/com/parse/ManifestInfo.java
@@ -388,6 +388,9 @@ import java.util.List;
     try {
       PackageInfo pi = context.getPackageManager().getPackageInfo(
           packageName, PackageManager.GET_PERMISSIONS);
+      if (pi.requestedPermissions == null) {
+        return false;
+      }
       return Arrays.asList(pi.requestedPermissions).containsAll(Arrays.asList(permissions));
     } catch (NameNotFoundException e) {
       PLog.e(TAG, "Couldn't find info about own package", e);


### PR DESCRIPTION
Our GCM permission checks would NPE if there were no permissions
defined. Adding a proper null check allows the system to properly
throw when missing required ACCESS_NETWORK_STATE or INTERNET
permissions

Example error with no permissions:

```
12-10 11:26:08.830 2457-2472/com.parse.starter E/AndroidRuntime: FATAL EXCEPTION: Parse.initialize Disk Check & Starting Command Cache
                                                                 Process: com.parse.starter, PID: 2457
                                                                 java.lang.SecurityException: ConnectivityService: Neither user 10064 nor current process has android.permission.ACCESS_NETWORK_STATE.
                                                                     at android.os.Parcel.readException(Parcel.java:1599)
                                                                     at android.os.Parcel.readException(Parcel.java:1552)
                                                                     at android.net.IConnectivityManager$Stub$Proxy.getActiveNetworkInfo(IConnectivityManager.java:974)
                                                                     at android.net.ConnectivityManager.getActiveNetworkInfo(ConnectivityManager.java:646)
                                                                     at com.parse.ConnectivityNotifier.isConnected(ConnectivityNotifier.java:43)
                                                                     at com.parse.ParsePinningEventuallyQueue.<init>(ParsePinningEventuallyQueue.java:89)
                                                                     at com.parse.Parse.getEventuallyQueue(Parse.java:417)
                                                                     at com.parse.Parse$1.run(Parse.java:216)
```