### PR TITLE
Prevent JSONObject/Array + Map/List combinations and unnecessary conversions back and forth

### DIFF
--- a/Parse/src/main/java/com/parse/ParseAnalytics.java
+++ b/Parse/src/main/java/com/parse/ParseAnalytics.java
@@ -13,6 +13,8 @@ import android.content.Intent;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -192,16 +194,15 @@ public class ParseAnalytics {
     if (name == null || name.trim().length() == 0) {
       throw new IllegalArgumentException("A name for the custom event must be provided.");
     }
-
-    final JSONObject jsonDimensions = dimensions != null
-        ? (JSONObject) NoObjectsEncoder.get().encode(dimensions)
+    final Map<String, String> dimensionsCopy = dimensions != null
+        ? Collections.unmodifiableMap(new HashMap<>(dimensions))
         : null;
 
     return ParseUser.getCurrentSessionTokenAsync().onSuccessTask(new Continuation<String, Task<Void>>() {
       @Override
       public Task<Void> then(Task<String> task) throws Exception {
         String sessionToken = task.getResult();
-        return getAnalyticsController().trackEventInBackground(name, jsonDimensions, sessionToken);
+        return getAnalyticsController().trackEventInBackground(name, dimensionsCopy, sessionToken);
       }
     });
   }

--- a/Parse/src/main/java/com/parse/ParseAnalyticsController.java
+++ b/Parse/src/main/java/com/parse/ParseAnalyticsController.java
@@ -10,6 +10,8 @@ package com.parse;
 
 import org.json.JSONObject;
 
+import java.util.Map;
+
 import bolts.Task;
 
 /** package */ class ParseAnalyticsController {
@@ -21,8 +23,8 @@ import bolts.Task;
   }
 
   public Task<Void> trackEventInBackground(final String name,
-    JSONObject jsonDimensions, String sessionToken) {
-    ParseRESTCommand command = ParseRESTAnalyticsCommand.trackEventCommand(name, jsonDimensions,
+    Map<String, String> dimensions, String sessionToken) {
+    ParseRESTCommand command = ParseRESTAnalyticsCommand.trackEventCommand(name, dimensions,
         sessionToken);
 
     Task<JSONObject> eventuallyTask = eventuallyQueue.enqueueEventuallyAsync(command, null);

--- a/Parse/src/main/java/com/parse/ParseConfig.java
+++ b/Parse/src/main/java/com/parse/ParseConfig.java
@@ -9,7 +9,6 @@
 package com.parse;
 
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.Collections;
@@ -104,13 +103,18 @@ public class ParseConfig {
     });
   }
 
-  /* package */ ParseConfig(JSONObject object, ParseDecoder decoder) {
-    Map<String, Object> decodedObject = (Map<String, Object>) decoder.decode(object);
+  @SuppressWarnings("unchecked")
+  /* package */ static ParseConfig decode(JSONObject json, ParseDecoder decoder) {
+    Map<String, Object> decodedObject = (Map<String, Object>) decoder.decode(json);
     Map<String, Object> decodedParams = (Map<String, Object>) decodedObject.get("params");
     if (decodedParams == null) {
       throw new RuntimeException("Object did not contain the 'params' key.");
     }
-    this.params = Collections.unmodifiableMap(decodedParams);
+    return new ParseConfig(decodedParams);
+  }
+
+  /* package */ ParseConfig(Map<String, Object> params) {
+    this.params = Collections.unmodifiableMap(params);
   }
 
   /* package */ ParseConfig() {

--- a/Parse/src/main/java/com/parse/ParseConfigController.java
+++ b/Parse/src/main/java/com/parse/ParseConfigController.java
@@ -35,7 +35,7 @@ import bolts.Task;
       public Task<ParseConfig> then(Task<JSONObject> task) throws Exception {
         JSONObject result = task.getResult();
 
-        final ParseConfig config = new ParseConfig(result, ParseDecoder.get());
+        final ParseConfig config = ParseConfig.decode(result, ParseDecoder.get());
         return currentConfigController.setCurrentConfigAsync(config).continueWith(new Continuation<Void, ParseConfig>() {
           @Override
           public ParseConfig then(Task<Void> task) throws Exception {

--- a/Parse/src/main/java/com/parse/ParseCurrentConfigController.java
+++ b/Parse/src/main/java/com/parse/ParseCurrentConfigController.java
@@ -68,7 +68,7 @@ import bolts.Task;
     } catch (IOException | JSONException e) {
       return null;
     }
-    return new ParseConfig(json, ParseDecoder.get());
+    return ParseConfig.decode(json, ParseDecoder.get());
   }
 
   /* package */ void clearCurrentConfigForTesting() {

--- a/Parse/src/main/java/com/parse/ParseEncoder.java
+++ b/Parse/src/main/java/com/parse/ParseEncoder.java
@@ -16,7 +16,6 @@ import org.json.JSONObject;
 
 import java.util.Collection;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -29,11 +28,19 @@ import java.util.Map;
 /** package */ abstract class ParseEncoder {
 
   /* package */ static boolean isValidType(Object value) {
-    return value instanceof JSONObject || value instanceof JSONArray || value instanceof String
-        || value instanceof Number || value instanceof Boolean || value == JSONObject.NULL
-        || value instanceof ParseObject || value instanceof ParseACL || value instanceof ParseFile
-        || value instanceof ParseGeoPoint || value instanceof Date || value instanceof byte[]
-        || value instanceof List || value instanceof Map || value instanceof ParseRelation;
+    return value instanceof String
+        || value instanceof Number
+        || value instanceof Boolean
+        || value instanceof Date
+        || value instanceof List
+        || value instanceof Map
+        || value instanceof byte[]
+        || value == JSONObject.NULL
+        || value instanceof ParseObject
+        || value instanceof ParseACL
+        || value instanceof ParseFile
+        || value instanceof ParseGeoPoint
+        || value instanceof ParseRelation;
   }
 
   public Object encode(Object object) {
@@ -92,32 +99,12 @@ import java.util.Map;
         return json;
       }
 
-      if (object instanceof JSONObject) {
-        JSONObject map = (JSONObject) object;
-        JSONObject json = new JSONObject();
-        Iterator<?> keys = map.keys();
-        while (keys.hasNext()) {
-          String key = (String) keys.next();
-          json.put(key, encode(map.opt(key)));
-        }
-        return json;
-      }
-
       if (object instanceof Collection) {
         JSONArray array = new JSONArray();
         for (Object item : (Collection<?>) object) {
           array.put(encode(item));
         }
         return array;
-      }
-
-      if (object instanceof JSONArray) {
-        JSONArray array = (JSONArray) object;
-        JSONArray json = new JSONArray();
-        for (int i = 0; i < array.length(); ++i) {
-          json.put(encode(array.opt(i)));
-        }
-        return json;
       }
 
       if (object instanceof ParseRelation) {

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -2918,6 +2918,14 @@ public class ParseObject {
       throw new IllegalArgumentException("value may not be null.");
     }
 
+    if (value instanceof JSONObject) {
+      ParseDecoder decoder = ParseDecoder.get();
+      value = decoder.convertJSONObjectToMap((JSONObject) value);
+    } else if (value instanceof JSONArray){
+      ParseDecoder decoder = ParseDecoder.get();
+      value = decoder.convertJSONArrayToList((JSONArray) value);
+    }
+
     if (!ParseEncoder.isValidType(value)) {
       throw new IllegalArgumentException("invalid type for value: " + value.getClass().toString());
     }
@@ -3166,12 +3174,6 @@ public class ParseObject {
   public <T> List<T> getList(String key) {
     synchronized (mutex) {
       Object value = estimatedData.get(key);
-
-      if (value instanceof JSONArray) {
-        ParseDecoder decoder = ParseDecoder.get();
-        value = decoder.convertJSONArrayToList((JSONArray) value);
-      }
-
       if (!(value instanceof List)) {
         return null;
       }
@@ -3192,12 +3194,6 @@ public class ParseObject {
   public <V> Map<String, V> getMap(String key) {
     synchronized (mutex) {
       Object value = estimatedData.get(key);
-
-      if (value instanceof JSONObject) {
-        ParseDecoder decoder = ParseDecoder.get();
-        value = decoder.convertJSONObjectToMap((JSONObject) value);
-      }
-
       if (!(value instanceof Map)) {
         return null;
       }

--- a/Parse/src/main/java/com/parse/ParseRESTCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTCommand.java
@@ -137,7 +137,7 @@ import bolts.Task;
         sessionToken);
   }
 
-  protected ParseRESTCommand(
+  public ParseRESTCommand(
       String httpPath,
       ParseHttpRequest.Method httpMethod,
       JSONObject jsonParameters,

--- a/Parse/src/main/java/com/parse/ParseRESTObjectBatchCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTObjectBatchCommand.java
@@ -18,9 +18,7 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import bolts.Continuation;
 import bolts.Task;
@@ -59,7 +57,8 @@ import bolts.Task;
       tasks.add(tcs.getTask());
     }
 
-    List<JSONObject> requests = new ArrayList<>(batchSize);
+    JSONObject parameters = new JSONObject();
+    JSONArray requests = new JSONArray();
     try {
       for (ParseRESTObjectCommand command : commands) {
         JSONObject requestParameters = new JSONObject();
@@ -69,14 +68,13 @@ import bolts.Task;
         if (body != null) {
           requestParameters.put("body", body);
         }
-        requests.add(requestParameters);
+        requests.put(requestParameters);
       }
+      parameters.put("requests", requests);
     } catch (JSONException e) {
       throw new RuntimeException(e);
     }
 
-    Map<String, List<JSONObject>> parameters = new HashMap<>();
-    parameters.put("requests", requests);
     ParseRESTCommand command = new ParseRESTObjectBatchCommand(
         "batch", ParseHttpRequest.Method.POST, parameters, sessionToken);
 
@@ -132,7 +130,7 @@ import bolts.Task;
   private ParseRESTObjectBatchCommand(
       String httpPath,
       ParseHttpRequest.Method httpMethod,
-      Map<String, ?> parameters,
+      JSONObject parameters,
       String sessionToken) {
     super(httpPath, httpMethod, parameters, sessionToken);
   }

--- a/Parse/src/test/java/com/parse/ParseAnalyticsControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParseAnalyticsControllerTest.java
@@ -12,10 +12,11 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import bolts.Task;
 
@@ -56,9 +57,9 @@ public class ParseAnalyticsControllerTest {
 
     // Execute
     ParseAnalyticsController controller = new ParseAnalyticsController(queue);
-    JSONObject json = new JSONObject();
-    json.put("event", "close");
-    ParseTaskUtils.wait(controller.trackEventInBackground("name", json, "sessionToken"));
+    Map<String, String> dimensions = new HashMap<>();
+    dimensions.put("event", "close");
+    ParseTaskUtils.wait(controller.trackEventInBackground("name", dimensions, "sessionToken"));
 
     // Verify eventuallyQueue.enqueueEventuallyAsync
     ArgumentCaptor<ParseRESTCommand> command = ArgumentCaptor.forClass(ParseRESTCommand.class);

--- a/Parse/src/test/java/com/parse/ParseConfigTest.java
+++ b/Parse/src/test/java/com/parse/ParseConfigTest.java
@@ -9,7 +9,6 @@
 package com.parse;
 
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -71,25 +70,25 @@ public class ParseConfigTest {
   }
 
   @Test
-  public void testConstructWithValidJsonObject() throws Exception {
+  public void testDecodeWithValidJsonObject() throws Exception {
     final Map<String, Object> params = new HashMap<>();
     params.put("string", "value");
     JSONObject json = new JSONObject();
     json.put("params", NoObjectsEncoder.get().encode(params));
 
-    ParseConfig config = new ParseConfig(json, ParseDecoder.get());
+    ParseConfig config = ParseConfig.decode(json, ParseDecoder.get());
     assertEquals(1, config.params.size());
     assertEquals("value", config.params.get("string"));
   }
 
   @Test(expected = RuntimeException.class)
-  public void testConstructWithInvalidJsonObject() throws Exception {
+  public void testDecodeWithInvalidJsonObject() throws Exception {
     final Map<String, Object> params = new HashMap<>();
     params.put("string", "value");
     JSONObject json = new JSONObject();
     json.put("error", NoObjectsEncoder.get().encode(params));
 
-    ParseConfig config = new ParseConfig(json, ParseDecoder.get());
+    ParseConfig.decode(json, ParseDecoder.get());
   }
 
   //endregion
@@ -98,10 +97,10 @@ public class ParseConfigTest {
 
   @Test
   public void testGetInBackgroundSuccess() throws Exception {
-    final Map<String, Object> params = new HashMap<String, Object>();
+    final Map<String, Object> params = new HashMap<>();
     params.put("string", "value");
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     ParseConfigController controller = mockParseConfigControllerWithResponse(config);
     ParseCorePlugins.getInstance().registerConfigController(controller);
 
@@ -114,6 +113,7 @@ public class ParseConfigTest {
     assertEquals("value", configAgain.params.get("string"));
   }
 
+  @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
   @Test
   public void testGetInBackgroundFail() throws Exception {
     ParseException exception = new ParseException(ParseException.CONNECTION_FAILED, "error");
@@ -135,7 +135,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("string", "value");
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     ParseConfigController controller = mockParseConfigControllerWithResponse(config);
     ParseCorePlugins.getInstance().registerConfigController(controller);
 
@@ -180,7 +180,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("string", "value");
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     ParseConfigController controller = mockParseConfigControllerWithResponse(config);
     ParseCorePlugins.getInstance().registerConfigController(controller);
 
@@ -216,7 +216,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("string", "value");
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     ParseConfigController controller = new ParseConfigController(mock(ParseHttpClient.class),
         mockParseCurrentConfigControllerWithResponse(config));
     ParseCorePlugins.getInstance().registerConfigController(controller);
@@ -246,7 +246,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", true);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertTrue(config.getBoolean("key"));
     assertTrue(config.getBoolean("key", false));
   }
@@ -256,7 +256,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", true);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertFalse(config.getBoolean("wrongKey"));
     assertFalse(config.getBoolean("wrongKey", false));
   }
@@ -266,7 +266,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertFalse(config.getBoolean("key"));
     assertFalse(config.getBoolean("key", false));
   }
@@ -280,7 +280,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 998);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertEquals(config.getInt("key"), 998);
     assertEquals(998, config.getInt("key", 100));
   }
@@ -290,7 +290,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 998);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertEquals(config.getInt("wrongKey"), 0);
     assertEquals(100, config.getInt("wrongKey", 100));
   }
@@ -304,7 +304,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 998.1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertEquals(config.getDouble("key"), 998.1, 0.0001);
     assertEquals(998.1, config.getDouble("key", 100.1), 0.0001);
   }
@@ -314,7 +314,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 998.1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertEquals(config.getDouble("wrongKey"), 0.0, 0.0001);
     assertEquals(100.1, config.getDouble("wrongKey", 100.1), 0.0001);
   }
@@ -328,7 +328,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", (long)998);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertEquals(config.getLong("key"), (long)998);
     assertEquals((long)998, config.getLong("key", (long) 100));
   }
@@ -338,7 +338,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", (long)998);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertEquals(config.getLong("wrongKey"), (long)0);
     assertEquals((long)100, config.getLong("wrongKey", (long) 100));
   }
@@ -352,7 +352,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", "value");
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertEquals(config.get("key"), "value");
     assertEquals("value", config.get("key", "haha"));
   }
@@ -362,7 +362,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", "value");
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.get("wrongKey"));
     assertEquals("haha", config.get("wrongKey", "haha"));
   }
@@ -373,7 +373,7 @@ public class ParseConfigTest {
     params.put("key", JSONObject.NULL);
     params.put("keyAgain", null);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.get("key"));
     assertNull(config.get("key", "haha"));
     assertNull(config.get("keyAgain"));
@@ -389,7 +389,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", "value");
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertEquals(config.getString("key"), "value");
     assertEquals("value", config.getString("key", "haha"));
   }
@@ -399,7 +399,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", "value");
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getString("wrongKey"));
     assertEquals("haha", config.getString("wrongKey", "haha"));
   }
@@ -409,7 +409,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getString("key"));
     assertEquals("haha", config.getString("key", "haha"));
   }
@@ -420,7 +420,7 @@ public class ParseConfigTest {
     params.put("key", JSONObject.NULL);
     params.put("keyAgain", null);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getString("key"));
     assertNull(config.getString("key", "haha"));
     assertNull(config.getString("keyAgain"));
@@ -440,7 +440,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", date);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertEquals(date.getTime(), config.getDate("key").getTime());
     assertEquals(date.getTime(), config.getDate("key", dateAgain).getTime());
   }
@@ -454,7 +454,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", date);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getDate("wrongKey"));
     assertSame(dateAgain, config.getDate("wrongKey", dateAgain));
   }
@@ -466,7 +466,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getDate("key"));
     assertSame(date, config.getDate("key", date));
   }
@@ -479,7 +479,7 @@ public class ParseConfigTest {
     params.put("key", JSONObject.NULL);
     params.put("keyAgain", null);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getDate("key"));
     assertNull(config.getDate("key", date));
     assertNull(config.getDate("keyAgain"));
@@ -503,7 +503,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", list);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertArrayEquals(list.toArray(), config.getList("key").toArray());
     assertArrayEquals(list.toArray(), config.getList("key", listAgain).toArray());
   }
@@ -521,7 +521,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", list);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getList("wrongKey"));
     assertSame(listAgain, config.getList("wrongKey", listAgain));
   }
@@ -535,7 +535,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getList("key"));
     assertSame(list, config.getList("key", list));
   }
@@ -550,7 +550,7 @@ public class ParseConfigTest {
     params.put("key", JSONObject.NULL);
     params.put("keyAgain", null);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getList("key"));
     assertNull(config.getList("key", list));
     assertNull(config.getList("keyAgain"));
@@ -568,7 +568,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", number);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertEquals(number, config.getNumber("key"));
     assertEquals(number, config.getNumber("key", numberAgain));
   }
@@ -580,7 +580,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", number);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getNumber("wrongKey"));
     assertSame(numberAgain, config.getNumber("wrongKey", numberAgain));
   }
@@ -591,7 +591,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", new ArrayList<String>());
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getNumber("key"));
     assertSame(number, config.getNumber("key", number));
   }
@@ -603,7 +603,7 @@ public class ParseConfigTest {
     params.put("key", JSONObject.NULL);
     params.put("keyAgain", null);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getNumber("key"));
     assertNull(config.getNumber("key", number));
     assertNull(config.getNumber("keyAgain"));
@@ -627,7 +627,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", map);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     Map<String, Object> mapConfig = config.getMap("key");
     assertEquals(3, mapConfig.size());
     assertEquals("foo", mapConfig.get("first"));
@@ -649,7 +649,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", map);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getMap("wrongKey"));
     assertSame(mapAgain, config.getMap("wrongKey", mapAgain));
   }
@@ -663,7 +663,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getMap("key"));
     assertSame(map, config.getMap("key", map));
   }
@@ -678,7 +678,7 @@ public class ParseConfigTest {
     params.put("key", JSONObject.NULL);
     params.put("keyAgain", null);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getMap("key"));
     assertNull(config.getMap("key", map));
     assertNull(config.getMap("keyAgain"));
@@ -691,16 +691,16 @@ public class ParseConfigTest {
 
   @Test
   public void testGetJsonObjectKeyExist() throws Exception {
-    final JSONObject json = new JSONObject();
-    json.put("key", "value");
-    final JSONObject jsonAgain = new JSONObject();
-    jsonAgain.put("keyAgain", "valueAgain");
+    final Map<String, String> value = new HashMap<>();
+    value.put("key", "value");
     final Map<String, Object> params = new HashMap<>();
-    params.put("key", json);
+    params.put("key", value);
 
-    ParseConfig config = createSampleParseConfig(params);
+    final JSONObject json = new JSONObject(value);
+
+    ParseConfig config = new ParseConfig(params);
     assertEquals(json, config.getJSONObject("key"), JSONCompareMode.NON_EXTENSIBLE);
-    assertEquals(json, config.getJSONObject("key", jsonAgain),
+    assertEquals(json, config.getJSONObject("key", new JSONObject()),
         JSONCompareMode.NON_EXTENSIBLE);
   }
 
@@ -711,10 +711,10 @@ public class ParseConfigTest {
     final JSONObject jsonAgain = new JSONObject();
     jsonAgain.put("keyAgain", "valueAgain");
     final Map<String, Object> params;
-    params = new HashMap<String, Object>();
+    params = new HashMap<>();
     params.put("key", json);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getJSONObject("wrongKey"));
     //TODO(mengyan) ParseConfig.getJSONObject should return jsonAgain, but due to the error in
     // ParseConfig.getJsonObject, this returns null right now. Revise when we correct the logic
@@ -729,7 +729,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getJSONObject("key"));
     //TODO(mengyan) ParseConfig.getJSONObject should return json, but due to the error in
     // ParseConfig.getJsonObject, this returns null right now. Revise when we correct the logic
@@ -745,7 +745,7 @@ public class ParseConfigTest {
     params.put("key", JSONObject.NULL);
     params.put("keyAgain", null);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getJSONObject("key"));
     assertNull(config.getJSONObject("key", json));
     assertNull(config.getJSONObject("keyAgain"));
@@ -758,22 +758,21 @@ public class ParseConfigTest {
 
   @Test
   public void testGetJsonArrayKeyExist() throws Exception {
-    final JSONObject json = new JSONObject();
-    json.put("key", "value");
-    final JSONObject jsonAgain = new JSONObject();
-    jsonAgain.put("keyAgain", "valueAgain");
-    final JSONArray jsonArray = new JSONArray();
-    jsonArray.put(0, json);
-    jsonArray.put(1, jsonAgain);
-    final JSONArray jsonArrayAgain = new JSONArray();
-    jsonArray.put(0, jsonAgain);
-    jsonArray.put(1, json);
+    final Map<String, String> map = new HashMap<>();
+    map.put("key", "value");
+    final Map<String, String> mapAgain = new HashMap<>();
+    mapAgain.put("keyAgain", "valueAgain");
+    final List<Map<String, String>> value = new ArrayList<>();
+    value.add(map);
+    value.add(mapAgain);
     final Map<String, Object> params = new HashMap<>();
-    params.put("key", jsonArray);
+    params.put("key", value);
 
-    ParseConfig config = createSampleParseConfig(params);
+    JSONArray jsonArray = new JSONArray(value);
+
+    ParseConfig config = new ParseConfig(params);
     assertEquals(jsonArray, config.getJSONArray("key"), JSONCompareMode.NON_EXTENSIBLE);
-    assertEquals(jsonArray, config.getJSONArray("key", jsonArrayAgain),
+    assertEquals(jsonArray, config.getJSONArray("key", new JSONArray()),
         JSONCompareMode.NON_EXTENSIBLE);
   }
 
@@ -792,7 +791,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", jsonArray);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getJSONArray("wrongKey"));
     //TODO(mengyan) ParseConfig.getJSONArray should return default jsonArrayAgain, but due to the
     // error in ParseConfig.getJSONArray, this returns null right now. Revise when we correct the
@@ -812,7 +811,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getJSONArray("key"));
     //TODO(mengyan) ParseConfig.getJSONArray should return default jsonArray, but due to the
     // error in ParseConfig.getJSONArray, this returns null right now. Revise when we correct the
@@ -832,7 +831,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", null);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getJSONArray("key"));
     assertNull(config.getJSONArray("key", jsonArray));
     assertNull(config.getJSONArray("keyAgain"));
@@ -850,7 +849,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", geoPoint);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     ParseGeoPoint geoPointConfig = config.getParseGeoPoint("key");
     assertEquals(geoPoint.getLongitude(), geoPointConfig.getLongitude(), 0.0001);
     assertEquals(geoPoint.getLatitude(), geoPointConfig.getLatitude(), 0.0001);
@@ -864,7 +863,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", geoPoint);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getParseGeoPoint("wrongKey"));
     assertSame(geoPointAgain, config.getParseGeoPoint("wrongKey", geoPointAgain));
   }
@@ -875,7 +874,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getParseGeoPoint("key"));
     assertSame(geoPoint, config.getParseGeoPoint("key", geoPoint));
   }
@@ -887,7 +886,7 @@ public class ParseConfigTest {
     params.put("key", JSONObject.NULL);
     params.put("keyAgain", null);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getParseGeoPoint("key"));
     assertNull(config.getParseGeoPoint("key", geoPoint));
     assertNull(config.getParseGeoPoint("keyAgain"));
@@ -907,7 +906,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", file);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     ParseFile fileConfig = config.getParseFile("key");
     assertEquals(file.getName(), fileConfig.getName());
     assertEquals(file.getUrl(), fileConfig.getUrl());
@@ -923,7 +922,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", file);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getParseFile("wrongKey"));
     assertSame(fileAgain, config.getParseFile("wrongKey", fileAgain));
   }
@@ -935,7 +934,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("key", 1);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getParseFile("key"));
     assertSame(file, config.getParseFile("key", file));
   }
@@ -948,7 +947,7 @@ public class ParseConfigTest {
     params.put("key", JSONObject.NULL);
     params.put("keyAgain", JSONObject.NULL);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     assertNull(config.getParseFile("key"));
     assertNull(config.getParseFile("key", file));
     assertNull(config.getParseFile("keyAgain"));
@@ -969,7 +968,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("list", list);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     String configStr = config.toString();
     assertTrue(configStr.contains("ParseConfig"));
     assertTrue(configStr.contains("list"));
@@ -987,7 +986,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("map", map);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     String configStr = config.toString();
     assertTrue(configStr.contains("ParseConfig"));
     assertTrue(configStr.contains("map"));
@@ -1002,7 +1001,7 @@ public class ParseConfigTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("geoPoint", geoPoint);
 
-    ParseConfig config = createSampleParseConfig(params);
+    ParseConfig config = new ParseConfig(params);
     String configStr = config.toString();
     assertTrue(configStr.contains("ParseGeoPoint"));
     assertTrue(configStr.contains("45.484"));
@@ -1023,13 +1022,6 @@ public class ParseConfigTest {
     when(controller.getAsync(anyString()))
         .thenReturn(Task.<ParseConfig>forError(exception));
     return controller;
-  }
-
-  private ParseConfig createSampleParseConfig(final Map<String, Object> params)
-      throws JSONException {
-    JSONObject json = new JSONObject();
-    json.put("params", NoObjectsEncoder.get().encode(params));
-    return new ParseConfig(json, ParseDecoder.get());
   }
 
   private ParseCurrentConfigController mockParseCurrentConfigControllerWithResponse(

--- a/Parse/src/test/java/com/parse/ParseCurrentConfigControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParseCurrentConfigControllerTest.java
@@ -12,9 +12,6 @@ import org.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -87,7 +84,7 @@ public class ParseCurrentConfigControllerTest {
     JSONObject sampleConfigJson = new JSONObject() {{
       put("params", NoObjectsEncoder.get().encode(sampleConfigParameters));
     }};
-    ParseConfig config = new ParseConfig(sampleConfigJson, ParseDecoder.get());
+    ParseConfig config = ParseConfig.decode(sampleConfigJson, ParseDecoder.get());
 
     // Save to disk
     File configFile = new File(temporaryFolder.getRoot(), "config");
@@ -164,7 +161,7 @@ public class ParseCurrentConfigControllerTest {
     JSONObject sampleConfigJson = new JSONObject() {{
       put("params", NoObjectsEncoder.get().encode(sampleConfigParameters));
     }};
-    ParseConfig config = new ParseConfig(sampleConfigJson, ParseDecoder.get());
+    ParseConfig config = ParseConfig.decode(sampleConfigJson, ParseDecoder.get());
 
     // Save to disk
     File configFile = new File(temporaryFolder.getRoot(), "config");
@@ -272,7 +269,7 @@ public class ParseCurrentConfigControllerTest {
     JSONObject sampleConfigJson = new JSONObject() {{
       put("params", NoObjectsEncoder.get().encode(sampleConfigParameters));
     }};
-    ParseConfig diskConfig = new ParseConfig(sampleConfigJson, ParseDecoder.get());
+    ParseConfig diskConfig = ParseConfig.decode(sampleConfigJson, ParseDecoder.get());
     currentConfigController.saveToDisk(diskConfig);
 
     // Verify before set, disk config exist and in memory config is null

--- a/Parse/src/test/java/com/parse/ParseEncoderTest.java
+++ b/Parse/src/test/java/com/parse/ParseEncoderTest.java
@@ -123,17 +123,6 @@ public class ParseEncoderTest {
   }
 
   @Test
-  public void testJSONObject() throws JSONException {
-    JSONObject jsonObject = new JSONObject();
-    jsonObject.put("key1", "object1");
-    JSONObject mapJSON = (JSONObject) testClassObject.encode(jsonObject);
-    assertNotNull(mapJSON);
-    assertNotSame(jsonObject, mapJSON);
-    assertEquals(1, mapJSON.length());
-    assertEquals("object1", mapJSON.getString("key1"));
-  }
-
-  @Test
   public void testCollection() throws JSONException {
     ArrayList<Integer> list = new ArrayList<>();
     list.add(1);
@@ -143,26 +132,6 @@ public class ParseEncoderTest {
     assertEquals(2, jsonArray.length());
     assertEquals(1, jsonArray.get(0));
     assertEquals(2, jsonArray.get(1));
-  }
-
-  @Test
-  public void testJSONArray() throws JSONException {
-    JSONArray jsonArray = new JSONArray();
-    ParseGeoPoint parseGeoPoint = new ParseGeoPoint(30, -20);
-    jsonArray.put(parseGeoPoint);
-    Date date = ParseDateFormat.getInstance().parse("2011-08-21T18:02:52.249Z");
-    jsonArray.put(date);
-    jsonArray = (JSONArray) testClassObject.encode(jsonArray);
-    assertNotNull(jsonArray);
-    assertEquals(2, jsonArray.length());
-    JSONObject geoPointJSON = (JSONObject) jsonArray.get(0);
-    final double DELTA = 0.00001;
-    assertEquals("GeoPoint", geoPointJSON.getString("__type"));
-    assertEquals(30, geoPointJSON.getDouble("latitude"), DELTA);
-    assertEquals(-20, geoPointJSON.getDouble("longitude"), DELTA);
-    JSONObject dateJSON = (JSONObject) jsonArray.get(1);
-    assertEquals("Date", dateJSON.getString("__type"));
-    assertEquals("2011-08-21T18:02:52.249Z", dateJSON.getString("iso"));
   }
 
   @Test


### PR DESCRIPTION
We have a bunch of cases where we combine `JSONObject`/`JSONArray` and `Map`/`List` and a bunch of cases where unnecessarily convert `JSONObject` <-> `Map` and `JSONArray` <-> `List` back and forth. This PR simplifies things by removing `JSONObject` and `JSONArray` encoding so that we don't unnecessarily combine or convert back and forth.

* Convert ParseConfig JSON constructor to factory method
* Simplify ParseConfig tests to utilize Maps/Lists
* Do not convert Map -> JSONObject -> Map -> JSONObject for ParseAnalytics
* Do not combine JSONObject/Array with Map/List for ParseRESTObjectBatchCommand
* Do not combine Map & JSONObject for ParsePush
* Do not allow encoding JSONObject/JSONArray

Note: This breaks compatibility with ParseCrashReporting

Depends on #303