### PR TITLE
Remove Parse Gradle plugin from ParseStarterProject

### DIFF
--- a/ParseStarterProject/build.gradle
+++ b/ParseStarterProject/build.gradle
@@ -1,15 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.parse'
-
-buildscript {
-  repositories {
-    mavenCentral()
-    maven { url 'https://maven.parse.com/repo' }
-  }
-  dependencies {
-    classpath 'com.parse.tools:gradle:1.+'
-  }
-}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -36,13 +25,3 @@ dependencies {
     compile 'com.parse.bolts:bolts-tasks:1.3.0'
     compile project(':Parse')
 }
-
-/* Uncomment if you enable ProGuard and you want to automatically upload symbols on build.
-parse {
-  applicationId "YOUR_APPLICATION_ID"
-  masterKey "YOUR_MASTER_KEY"
-
-  // Make symbol upload automatic. Otherwise, use e.g. ../gradlew parseUploadSymbolsDebug;
-  uploadSymbols true
-}
-*/


### PR DESCRIPTION
No longer relevant without ParseCrashReporting support