### PR TITLE
Fix ParseUser#setState(state) unnecessarily creating authData

### DIFF
--- a/Parse/src/main/java/com/parse/ParseUser.java
+++ b/Parse/src/main/java/com/parse/ParseUser.java
@@ -510,7 +510,7 @@ public class ParseUser extends ParseObject {
         newStateBuilder.put(KEY_SESSION_TOKEN, getSessionToken());
       }
       // Avoid clearing authData when updating the current user's State via ParseQuery result
-      if (getAuthData() != null && newState.get(KEY_AUTH_DATA) == null) {
+      if (getAuthData().size() > 0 && newState.get(KEY_AUTH_DATA) == null) {
         newStateBuilder.put(KEY_AUTH_DATA, getAuthData());
       }
       newState = newStateBuilder.build();

--- a/Parse/src/test/java/com/parse/ParseUserTest.java
+++ b/Parse/src/test/java/com/parse/ParseUserTest.java
@@ -1428,7 +1428,36 @@ public class ParseUserTest {
     // Make sure we keep the authData
     assertEquals(1, user.getAuthData().size());
     assertEquals(authData, user.getAuthData().get(authType));
-    // Make sure old state is deleted
+    // Make sure old state is replaced
+    assertFalse(user.has("oldKey"));
+    // Make sure new state is set
+    assertEquals("testAgain", user.getObjectId());
+    assertEquals("valueAgain", user.get("key"));
+  }
+
+  @Test
+  public void testSetStateDoesNotAddNonExistentAuthData() throws Exception {
+    // Set user initial state
+    ParseUser.State userState = new ParseUser.State.Builder()
+        .objectId("test")
+        .put("oldKey", "oldValue")
+        .put("key", "value")
+        .build();
+    ParseUser user = ParseObject.from(userState);
+    user.setIsCurrentUser(true);
+    // Build new state
+    ParseUser.State newUserState = new ParseUser.State.Builder()
+        .objectId("testAgain")
+        .put("key", "valueAgain")
+        .build();
+
+    user.setState(newUserState);
+
+    // Make sure we do not add authData when it did not exist before
+    assertFalse(user.keySet().contains("authData"));
+    assertEquals(1, user.keySet().size());
+    assertEquals(0, user.getAuthData().size());
+    // Make sure old state is replaced
     assertFalse(user.has("oldKey"));
     // Make sure new state is set
     assertEquals("testAgain", user.getObjectId());


### PR DESCRIPTION
Fixing a bug that was introduced in #304 that caused `authData` to be created on `ParseUser#setState(state)` with a state that did not contain `authData` in the first place.