### PR TITLE
Simplify authenticating w/ third party & automatic users

### DIFF
--- a/Parse/src/main/java/com/parse/ParseUser.java
+++ b/Parse/src/main/java/com/parse/ParseUser.java
@@ -1127,7 +1127,7 @@ public class ParseUser extends ParseObject {
     };
 
     // Handle claiming of user.
-    return getCurrentUserAsync().onSuccessTask(new Continuation<ParseUser, Task<ParseUser>>() {
+    return getCurrentUserController().getAsync(false).onSuccessTask(new Continuation<ParseUser, Task<ParseUser>>() {
       @Override
       public Task<ParseUser> then(Task<ParseUser> task) throws Exception {
         final ParseUser user = task.getResult();


### PR DESCRIPTION
Authenticating with third party auth providers while automatic
users were enabled and no current user existed would cause an
automatic user to be created just to be resolved.

Instead, don't create an automatic user but just authenticate
normally.