### PR TITLE
Add configurable serverURL to Parse.Configuration.

### DIFF
--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -22,6 +22,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,6 +50,7 @@ public class Parse {
       private Context context;
       private String applicationId;
       private String clientKey;
+      private String server = "https://api.parse.com/1";
       private boolean localDataStoreEnabled;
       private List<ParseNetworkInterceptor> interceptors;
 
@@ -129,6 +132,20 @@ public class Parse {
       }
 
       /**
+       * Set the server URL to be used by Parse.
+       *
+       * This method is only required if you intend to use a different API server than the one at
+       * api.parse.com.
+       *
+       * @param server The server URL to set.
+       * @return The same builder, for easy chaining.
+       */
+      public Builder server(String server) {
+        this.server = server;
+        return this;
+      }
+
+      /**
        * Add a {@link ParseNetworkInterceptor}.
        *
        * @param interceptor The interceptor to add.
@@ -182,6 +199,7 @@ public class Parse {
     /* package for tests */ final Context context;
     /* package for tests */ final String applicationId;
     /* package for tests */ final String clientKey;
+    /* package for tests */ final String server;
     /* package for tests */ final boolean localDataStoreEnabled;
     /* package for tests */ final List<ParseNetworkInterceptor> interceptors;
 
@@ -189,6 +207,7 @@ public class Parse {
       this.context = builder.context;
       this.applicationId = builder.applicationId;
       this.clientKey = builder.clientKey;
+      this.server = builder.server;
       this.localDataStoreEnabled = builder.localDataStoreEnabled;
       this.interceptors = builder.interceptors != null ?
         Collections.unmodifiableList(new ArrayList<>(builder.interceptors)) :
@@ -356,6 +375,13 @@ public class Parse {
     isLocalDatastoreEnabled = configuration.localDataStoreEnabled;
 
     ParsePlugins.Android.initialize(configuration.context, configuration.applicationId, configuration.clientKey);
+
+    try {
+      ParseRESTCommand.server = new URL(configuration.server);
+    } catch (MalformedURLException ex) {
+      throw new RuntimeException(ex);
+    }
+
     Context applicationContext = configuration.context.getApplicationContext();
 
     ParseHttpClient.setKeepAlive(true);

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -49,7 +49,6 @@ import bolts.Task;
  * existing data to retrieve.
  */
 public class ParseObject {
-  /* package */ static String server = "https://api.parse.com";
   private static final String AUTO_CLASS_NAME = "_Automatic";
   /* package */ static final String VERSION_NAME = "1.12.1-SNAPSHOT";
 

--- a/Parse/src/main/java/com/parse/ParseRESTCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTCommand.java
@@ -19,6 +19,8 @@ import org.json.JSONStringer;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -43,6 +45,9 @@ import bolts.Task;
   private static final String HEADER_SESSION_TOKEN = "X-Parse-Session-Token";
   private static final String HEADER_MASTER_KEY = "X-Parse-Master-Key";
   private static final String PARAMETER_METHOD_OVERRIDE = "_method";
+
+  // Set via Parse.initialize(Configuration)
+  /* package */ static URL server = null;
 
   private static LocalIdManager getLocalIdManager() {
     return ParseCorePlugins.getInstance().getLocalIdManager();
@@ -189,7 +194,15 @@ import bolts.Task;
   private static String createUrl(String httpPath) {
     // We send all parameters for GET/HEAD/DELETE requests in a post body,
     // so no need to worry about query parameters here.
-    return String.format("%s/1/%s", ParseObject.server, httpPath);
+    if (httpPath == null) {
+      return server.toString();
+    }
+
+    try {
+      return new URL(server, httpPath).toString();
+    } catch (MalformedURLException ex) {
+      throw new RuntimeException(ex);
+    }
   }
 
   protected void addAdditionalHeaders(ParseHttpRequest.Builder requestBuilder) {

--- a/Parse/src/main/java/com/parse/ParseRESTObjectBatchCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTObjectBatchCommand.java
@@ -17,6 +17,8 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,7 +65,7 @@ import bolts.Task;
       for (ParseRESTObjectCommand command : commands) {
         JSONObject requestParameters = new JSONObject();
         requestParameters.put("method", command.method.toString());
-        requestParameters.put("path", String.format("/1/%s", command.httpPath));
+        requestParameters.put("path", new URL(server, command.httpPath).getPath());
         JSONObject body = command.jsonParameters;
         if (body != null) {
           requestParameters.put("body", body);
@@ -72,6 +74,8 @@ import bolts.Task;
       }
       parameters.put("requests", requests);
     } catch (JSONException e) {
+      throw new RuntimeException(e);
+    } catch (MalformedURLException e) {
       throw new RuntimeException(e);
     }
 

--- a/Parse/src/test/java/com/parse/NetworkObjectControllerTest.java
+++ b/Parse/src/test/java/com/parse/NetworkObjectControllerTest.java
@@ -13,12 +13,16 @@ import com.parse.http.ParseHttpResponse;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.ByteArrayInputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,6 +39,16 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
 public class NetworkObjectControllerTest {
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
+  }
+
+  @After
+  public void tearDown() {
+    ParseRESTCommand.server = null;
+  }
 
   //region testFetchAsync
 

--- a/Parse/src/test/java/com/parse/NetworkQueryControllerTest.java
+++ b/Parse/src/test/java/com/parse/NetworkQueryControllerTest.java
@@ -11,8 +11,12 @@ package com.parse;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 
 import bolts.Task;
@@ -22,6 +26,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class NetworkQueryControllerTest {
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
+  }
+
+  @After
+  public void tearDown() {
+    ParseRESTCommand.server = null;
+  }
 
   //region testConvertFindResponse
 

--- a/Parse/src/test/java/com/parse/NetworkSessionControllerTest.java
+++ b/Parse/src/test/java/com/parse/NetworkSessionControllerTest.java
@@ -10,11 +10,15 @@ package com.parse;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -25,6 +29,16 @@ import static org.junit.Assert.assertTrue;
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
 public class NetworkSessionControllerTest {
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
+  }
+
+  @After
+  public void tearDown() {
+    ParseRESTCommand.server = null;
+  }
 
   //region testGetSessionAsync
 

--- a/Parse/src/test/java/com/parse/NetworkUserControllerTest.java
+++ b/Parse/src/test/java/com/parse/NetworkUserControllerTest.java
@@ -10,11 +10,15 @@ package com.parse;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,6 +30,16 @@ import static org.junit.Assert.assertTrue;
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
 public class NetworkUserControllerTest {
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
+  }
+
+  @After
+  public void tearDown() {
+    ParseRESTCommand.server = null;
+  }
 
   //region testSignUpAsync
 

--- a/Parse/src/test/java/com/parse/ParseAnalyticsControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParseAnalyticsControllerTest.java
@@ -9,12 +9,16 @@
 package com.parse;
 
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,6 +38,16 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
 public class ParseAnalyticsControllerTest {
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
+  }
+
+  @After
+  public void tearDown() {
+    ParseRESTCommand.server = null;
+  }
 
   //region testConstructor
 

--- a/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
+++ b/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
@@ -30,12 +30,14 @@ public class ParseClientConfigurationTest {
     Parse.Configuration.Builder builder = new Parse.Configuration.Builder(null);
     builder.applicationId("foo");
     builder.clientKey("bar");
+    builder.server("some.server");
     builder.enableLocalDataStore();
     Parse.Configuration configuration = builder.build();
 
     assertNull(configuration.context);
     assertEquals(configuration.applicationId, "foo");
     assertEquals(configuration.clientKey, "bar");
+    assertEquals(configuration.server, "some.server");
     assertEquals(configuration.localDataStoreEnabled, true);
   }
 

--- a/Parse/src/test/java/com/parse/ParseCloudCodeControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParseCloudCodeControllerTest.java
@@ -13,10 +13,14 @@ import com.parse.http.ParseHttpResponse;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 
@@ -35,6 +39,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ParseCloudCodeControllerTest {
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
+  }
+
+  @After
+  public void tearDown() {
+    ParseRESTCommand.server = null;
+  }
 
   //region testConstructor
 

--- a/Parse/src/test/java/com/parse/ParseConfigControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParseConfigControllerTest.java
@@ -12,12 +12,16 @@ import com.parse.http.ParseHttpRequest;
 import com.parse.http.ParseHttpResponse;
 
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -41,6 +45,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ParseConfigControllerTest {
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
+  }
+
+  @After
+  public void tearDown() {
+    ParseRESTCommand.server = null;
+  }
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/Parse/src/test/java/com/parse/ParseFileControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParseFileControllerTest.java
@@ -13,6 +13,7 @@ import com.parse.http.ParseHttpResponse;
 
 import org.json.JSONObject;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -23,6 +24,8 @@ import org.robolectric.annotation.Config;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 import bolts.Task;
 
@@ -43,10 +46,16 @@ import static org.mockito.Mockito.when;
 @Config(constants = BuildConfig.class, sdk = 21)
 public class ParseFileControllerTest {
 
+  @Before
+  public void setUp() throws MalformedURLException {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
+  }
+
   @After
   public void tearDown() {
     // TODO(grantland): Remove once we no longer rely on retry logic.
     ParseRequest.setDefaultInitialRetryDelay(ParseRequest.DEFAULT_INITIAL_RETRY_DELAY);
+    ParseRESTCommand.server = null;
   }
 
   @Rule

--- a/Parse/src/test/java/com/parse/ParsePushControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParsePushControllerTest.java
@@ -14,6 +14,8 @@ import com.parse.http.ParseHttpResponse;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -22,6 +24,8 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,6 +47,16 @@ import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
 public class ParsePushControllerTest {
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
+  }
+
+  @After
+  public void tearDown() {
+    ParseRESTCommand.server = null;
+  }
 
   //region testBuildRESTSendPushCommand
 

--- a/Parse/src/test/java/com/parse/ParseRESTCommandTest.java
+++ b/Parse/src/test/java/com/parse/ParseRESTCommandTest.java
@@ -26,6 +26,8 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 import bolts.Task;
 
@@ -68,12 +70,14 @@ public class ParseRESTCommandTest {
   @Before
   public void setUp() throws Exception {
     ParseRequest.setDefaultInitialRetryDelay(1L);
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
   }
 
   @After
   public void tearDown() throws Exception {
     ParseRequest.setDefaultInitialRetryDelay(ParseRequest.DEFAULT_INITIAL_RETRY_DELAY);
     ParseCorePlugins.getInstance().reset();
+    ParseRESTCommand.server = null;
   }
 
   @Test

--- a/Parse/src/test/java/com/parse/ParseRESTQueryCommandTest.java
+++ b/Parse/src/test/java/com/parse/ParseRESTQueryCommandTest.java
@@ -12,9 +12,13 @@ import com.parse.http.ParseHttpRequest;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -24,6 +28,16 @@ import static org.junit.Assert.assertTrue;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 public class ParseRESTQueryCommandTest {
+
+  @Before
+  public void setUp() throws MalformedURLException {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
+  }
+
+  @After
+  public void tearDown() {
+    ParseRESTCommand.server = null;
+  }
 
   //region testEncode
 

--- a/Parse/src/test/java/com/parse/ParseRESTUserCommandTest.java
+++ b/Parse/src/test/java/com/parse/ParseRESTUserCommandTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.ByteArrayInputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,13 +31,15 @@ import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 public class ParseRESTUserCommandTest {
 
   @Before
-  public void setUp() {
+  public void setUp() throws MalformedURLException {
     ParseObject.registerSubclass(ParseUser.class);
+    ParseRESTCommand.server = new URL("https://api.parse.com/1");
   }
 
   @After
   public void tearDown() {
     ParseObject.unregisterSubclass(ParseUser.class);
+    ParseRESTCommand.server = null;
   }
 
   //region testConstruct


### PR DESCRIPTION
Moves `server` from ParseObject to ParseRestCommand, and allows it to be
changed via `Builder.server("myUrl")`.