### PR TITLE
Fix default parse server url

### DIFF
--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -50,7 +50,7 @@ public class Parse {
       private Context context;
       private String applicationId;
       private String clientKey;
-      private String server = "https://api.parse.com/1";
+      private String server = "https://api.parse.com/1/";
       private boolean localDataStoreEnabled;
       private List<ParseNetworkInterceptor> interceptors;
 

--- a/Parse/src/test/java/com/parse/ParseRESTCommandTest.java
+++ b/Parse/src/test/java/com/parse/ParseRESTCommandTest.java
@@ -80,6 +80,17 @@ public class ParseRESTCommandTest {
     ParseRESTCommand.server = null;
   }
 
+
+  @Test
+  public void testInitializationWithDefaultParseServerURL() throws Exception {
+    ParseRESTCommand.server = new URL("https://api.parse.com/1/");
+    ParseRESTCommand command = new ParseRESTCommand.Builder()
+        .httpPath("events/Appopened")
+        .build();
+
+    assertEquals("https://api.parse.com/1/events/Appopened", command.url);
+  }
+
   @Test
   public void testPermanentFailures() throws Exception {
     JSONObject json = new JSONObject();


### PR DESCRIPTION
We need to add additional `/` at the end of our default server URL address. Otherwise, when we use `new URL(server, httpPath)` to build the URL [here](https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/ParseRESTCommand.java#L194), the `/1` will be ignored.
cc @richardjrossiii 