### PR TITLE
Avoid add unnecessary ParseDecompressInterceptor

### DIFF
--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -387,7 +387,7 @@ public class Parse {
     ParseHttpClient.setKeepAlive(true);
     ParseHttpClient.setMaxConnections(20);
     // If we have interceptors in list, we have to initialize all http clients and add interceptors
-    if (configuration.interceptors != null) {
+    if (configuration.interceptors != null && configuration.interceptors.size() > 0) {
       initializeParseHttpClientsWithParseNetworkInterceptors(configuration.interceptors);
     }
 


### PR DESCRIPTION
Fixes #355 
We set network interceptor like this, when developers do not add external interceptors, parameter `interceptors` is null
```java
 initialize(builder.setNetworkInterceptors(interceptors)
    .setLocalDatastoreEnabled(isLocalDatastoreEnabled)
    .build()
 );
```
[link](https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/Parse.java#L330)
 
For the `Configuration.builder`, its `interceptors` will never be null
```java
/* package for tests */ Builder setNetworkInterceptors(Collection<ParseNetworkInterceptor> interceptors) {
  if (this.interceptors == null) {
    this.interceptors = new ArrayList<>();
  } else {
    this.interceptors.clear();
  }

  if (interceptors != null) {
    this.interceptors.addAll(interceptors);
  }
  return this;
}
```
[link](https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/Parse.java#L172)

Thus, in `Parse.initialize()`, the checking is actually useless since `configuration.interceptors` will never be null. This will make us always add `ParseDecompressInterceptor`.
```
// If we have interceptors in list, we have to initialize all http clients and add interceptors
if (configuration.interceptors != null) {
  initializeParseHttpClientsWithParseNetworkInterceptors(configuration.interceptors);
}
``` 
[link](https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/Parse.java#L391).

To fix this, we should also check the size of the list. 
cc @richardjrossiii 