### PR TITLE
Remove Content-Encoding header when we auto unzip the response steram

### DIFF
--- a/Parse/src/main/java/com/parse/ParseApacheHttpClient.java
+++ b/Parse/src/main/java/com/parse/ParseApacheHttpClient.java
@@ -52,6 +52,9 @@ import java.util.Map;
  */
 @SuppressWarnings("deprecation")
 /** package */ class ParseApacheHttpClient extends ParseHttpClient<HttpUriRequest, HttpResponse> {
+
+  private static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
+
   private DefaultHttpClient apacheClient;
 
   public ParseApacheHttpClient(int socketOperationTimeout, SSLSessionCache sslSessionCache) {
@@ -148,6 +151,10 @@ import java.util.Map;
     Map<String, String> headers = new HashMap<>();
     for (Header header : apacheResponse.getAllHeaders()) {
       headers.put(header.getName(), header.getValue());
+    }
+    // If we auto unzip the response stream, we should remove the content-encoding header
+    if (!disableHttpLibraryAutoDecompress()) {
+      headers.remove(CONTENT_ENCODING_HEADER);
     }
 
     // Content type

--- a/Parse/src/test/java/com/parse/ParseHttpClientTest.java
+++ b/Parse/src/test/java/com/parse/ParseHttpClientTest.java
@@ -202,6 +202,9 @@ public class ParseHttpClientTest {
 
     assertEquals("gzip", recordedHeaders.get("Accept-Encoding"));
 
+    // Verify we do not have Content-Encoding header
+    assertNull(parseResponse.getHeader("Content-Encoding"));
+
     // Verify response body
     byte[] content = ParseIOUtils.toByteArray(parseResponse.getContent());
     assertArrayEquals(responseContent.getBytes(), content);


### PR DESCRIPTION
Fixes #355 
When we use `ParseApacheHttpClient`, after we unzip the response stream, we should also remove the `Content-Encoding` header.