### PR TITLE
Fixed bug in ParseOkHttpClient which didn't handle ParseFile File uploads properly.

### DIFF
--- a/Parse/src/main/java/com/parse/ParseOkHttpClient.java
+++ b/Parse/src/main/java/com/parse/ParseOkHttpClient.java
@@ -146,9 +146,7 @@ import okio.Okio;
     // Set Body
     ParseHttpBody parseBody = parseRequest.getBody();
     ParseOkHttpRequestBody okHttpRequestBody = null;
-    if(parseBody instanceof ParseByteArrayHttpBody) {
-      okHttpRequestBody = new ParseOkHttpRequestBody(parseBody);
-    }
+    okHttpRequestBody = new ParseOkHttpRequestBody(parseBody);
     switch (method) {
       case PUT:
         okHttpRequestBuilder.put(okHttpRequestBody);


### PR DESCRIPTION
This check was unnecessary and in the event of a ParseFileHttpBody it would result in a null body for the Http POST which throws an exception.
Alternatively it could be replaced with the following:

``` java
if(parseBody instanceof ParseByteArrayHttpBody || parseBody instanceof ParseFileHttpBody) {
  okHttpRequestBody = new ParseOkHttpRequestBody(parseBody);
}
```

However both of those classes extend ParseHttpBody and they are the only classes that do so and the constructor for ParseOkHttpRequestBody is expecting type ParseHttpBody which they both extend so it seems as though the check is unnecessary.

This fixes File uploads as part of a ParseFile. Previously it was throwing the exception:

```
com.parse.ParseException: java.lang.IllegalArgumentException: method POST must have a request body.
01-22 14:03:12.982 24657-24657/com.plus11.ncredible W/System.err:     at com.parse.ParseTaskUtils$2$1.run(ParseTaskUtils.java:114)
01-22 14:03:12.983 24657-24657/com.plus11.ncredible W/System.err:     at android.os.Handler.handleCallback(Handler.java:739)
01-22 14:03:12.983 24657-24657/com.plus11.ncredible W/System.err:     at android.os.Handler.dispatchMessage(Handler.java:95)
01-22 14:03:12.983 24657-24657/com.plus11.ncredible W/System.err:     at android.os.Looper.loop(Looper.java:148)
01-22 14:03:12.983 24657-24657/com.plus11.ncredible W/System.err:     at android.app.ActivityThread.main(ActivityThread.java:5417)
01-22 14:03:12.983 24657-24657/com.plus11.ncredible W/System.err:     at java.lang.reflect.Method.invoke(Native Method)
01-22 14:03:12.983 24657-24657/com.plus11.ncredible W/System.err:     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
01-22 14:03:12.983 24657-24657/com.plus11.ncredible W/System.err:     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
01-22 14:03:12.984 24657-24657/com.plus11.ncredible W/System.err: Caused by: java.lang.IllegalArgumentException: method POST must have a request body.
01-22 14:03:12.984 24657-24657/com.plus11.ncredible W/System.err:     at com.squareup.okhttp.Request$Builder.method(Request.java:256)
01-22 14:03:12.984 24657-24657/com.plus11.ncredible W/System.err:     at com.squareup.okhttp.Request$Builder.post(Request.java:229)
01-22 14:03:12.985 24657-24657/com.plus11.ncredible W/System.err:     at com.parse.ParseOkHttpClient.getRequest(ParseOkHttpClient.java:157)
01-22 14:03:12.985 24657-24657/com.plus11.ncredible W/System.err:     at com.parse.ParseOkHttpClient.executeInternal(ParseOkHttpClient.java:66)
01-22 14:03:12.985 24657-24657/com.plus11.ncredible W/System.err:     at com.parse.ParseHttpClient$ParseNetworkInterceptorChain.proceed(ParseHttpClient.java:158)
01-22 14:03:12.985 24657-24657/com.plus11.ncredible W/System.err:     at com.parse.ParsePlugins$1.intercept(ParsePlugins.java:115)
01-22 14:03:12.985 24657-24657/com.plus11.ncredible W/System.err:     at com.parse.ParseHttpClient$ParseNetworkInterceptorChain.proceed(ParseHttpClient.java:147)
01-22 14:03:12.985 24657-24657/com.plus11.ncredible W/System.err:     at com.parse.ParseHttpClient.execute(ParseHttpClient.java:122)
01-22 14:03:12.986 24657-24657/com.plus11.ncredible W/System.err:     at com.parse.ParseRequest$3.then(ParseRequest.java:136)
01-22 14:03:12.986 24657-24657/com.plus11.ncredible W/System.err:     at com.parse.ParseRequest$3.then(ParseRequest.java:133)
01-22 14:03:12.986 24657-24657/com.plus11.ncredible W/System.err:     at bolts.Task$15.run(Task.java:839)
01-22 14:03:12.986 24657-24657/com.plus11.ncredible W/System.err:     at bolts.BoltsExecutors$ImmediateExecutor.execute(BoltsExecutors.java:105)
01-22 14:03:12.986 24657-24657/com.plus11.ncredible W/System.err:     at bolts.Task.completeAfterTask(Task.java:830)
01-22 14:03:12.986 24657-24657/com.plus11.ncredible W/System.err:     at bolts.Task.continueWithTask(Task.java:642)
01-22 14:03:12.987 24657-24657/com.plus11.ncredible W/System.err:     at bolts.Task.continueWithTask(Task.java:653)
01-22 14:03:12.987 24657-24657/com.plus11.ncredible W/System.err:     at bolts.Task$13.then(Task.java:745)
01-22 14:03:12.987 24657-24657/com.plus11.ncredible W/System.err:     at bolts.Task$13.then(Task.java:733)
01-22 14:03:12.987 24657-24657/com.plus11.ncredible W/System.err:     at bolts.Task$15.run(Task.java:839)
01-22 14:03:12.987 24657-24657/com.plus11.ncredible W/System.err:     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
01-22 14:03:12.987 24657-24657/com.plus11.ncredible W/System.err:     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
01-22 14:03:12.988 24657-24657/com.plus11.ncredible W/System.err:     at java.lang.Thread.run(Thread.java:818)
```
