### PR TITLE
Use push_id instead of push_hash

### DIFF
--- a/Parse/src/main/java/com/parse/ParseAnalytics.java
+++ b/Parse/src/main/java/com/parse/ParseAnalytics.java
@@ -221,24 +221,33 @@ public class ParseAnalytics {
   }
 
   /* package for test */ static String getPushIdFromIntent(Intent intent) {
-    String pushData = null;
-    if (intent != null && intent.getExtras() != null) {
-      pushData = intent.getExtras().getString(ParsePushBroadcastReceiver.KEY_PUSH_DATA);
-    }
-    if (pushData == null) {
+    if (intent == null || intent.getExtras() == null) {
       return null;
     }
-    String pushId;
+
+    JSONObject pushData;
     try {
-      JSONObject payload = new JSONObject(pushData);
-      pushId = payload.optString("push_id");
+      String string = intent.getExtras().getString(ParsePushBroadcastReceiver.KEY_PUSH_DATA);
+      if (string == null) {
+        return null;
+      }
+
+      pushData = new JSONObject(string);
     } catch (JSONException e) {
       PLog.e(TAG, "Failed to parse push data: " + e.getMessage());
       return null;
     }
-    if (pushId.length() <= 0) {
+
+    JSONObject parseMetadata = pushData.optJSONObject("parseMetadata");
+    if (parseMetadata == null) {
       return null;
     }
-    return pushId;
+
+    String id = parseMetadata.optString("id");
+    if (ParseTextUtils.isEmpty(id)) {
+      return null;
+    }
+
+    return id;
   }
 }

--- a/Parse/src/main/java/com/parse/ParseAnalytics.java
+++ b/Parse/src/main/java/com/parse/ParseAnalytics.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import bolts.Capture;
 import bolts.Continuation;
 import bolts.Task;
 
@@ -45,15 +44,13 @@ public class ParseAnalytics {
    * @return A Task that is resolved when the event has been tracked by Parse.
    */
   public static Task<Void> trackAppOpenedInBackground(Intent intent) {
-    String pushHashStr = getPushHashFromIntent(intent);
-    final Capture<String> pushHash = new Capture<>();
-    if (pushHashStr != null && pushHashStr.length() > 0) {
+    final String pushId = getPushIdFromIntent(intent);
+    if (pushId != null) {
       synchronized (lruSeenPushes) {
-        if (lruSeenPushes.containsKey(pushHashStr)) {
+        if (lruSeenPushes.containsKey(pushId)) {
           return Task.forResult(null);
         } else {
-          lruSeenPushes.put(pushHashStr, true);
-          pushHash.set(pushHashStr);
+          lruSeenPushes.put(pushId, true);
         }
       }
     }
@@ -61,7 +58,7 @@ public class ParseAnalytics {
       @Override
       public Task<Void> then(Task<String> task) throws Exception {
         String sessionToken = task.getResult();
-        return getAnalyticsController().trackAppOpenedInBackground(pushHash.get(), sessionToken);
+        return getAnalyticsController().trackAppOpenedInBackground(pushId, sessionToken);
       }
     });
   }
@@ -223,7 +220,7 @@ public class ParseAnalytics {
     }
   }
 
-  /* package for test */ static String getPushHashFromIntent(Intent intent) {
+  /* package for test */ static String getPushIdFromIntent(Intent intent) {
     String pushData = null;
     if (intent != null && intent.getExtras() != null) {
       pushData = intent.getExtras().getString(ParsePushBroadcastReceiver.KEY_PUSH_DATA);
@@ -231,13 +228,17 @@ public class ParseAnalytics {
     if (pushData == null) {
       return null;
     }
-    String pushHash = null;
+    String pushId;
     try {
       JSONObject payload = new JSONObject(pushData);
-      pushHash = payload.optString("push_hash");
+      pushId = payload.optString("push_id");
     } catch (JSONException e) {
       PLog.e(TAG, "Failed to parse push data: " + e.getMessage());
+      return null;
     }
-    return pushHash;
+    if (pushId.length() <= 0) {
+      return null;
+    }
+    return pushId;
   }
 }

--- a/Parse/src/main/java/com/parse/ParseAnalyticsController.java
+++ b/Parse/src/main/java/com/parse/ParseAnalyticsController.java
@@ -31,8 +31,8 @@ import bolts.Task;
     return eventuallyTask.makeVoid();
   }
 
-  public Task<Void> trackAppOpenedInBackground(String pushHash, String sessionToken) {
-    ParseRESTCommand command = ParseRESTAnalyticsCommand.trackAppOpenedCommand(pushHash,
+  public Task<Void> trackAppOpenedInBackground(String pushId, String sessionToken) {
+    ParseRESTCommand command = ParseRESTAnalyticsCommand.trackAppOpenedCommand(pushId,
         sessionToken);
 
     Task<JSONObject> eventuallyTask = eventuallyQueue.enqueueEventuallyAsync(command, null);

--- a/Parse/src/main/java/com/parse/ParseRESTAnalyticsCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTAnalyticsCommand.java
@@ -29,12 +29,12 @@ import java.util.Map;
   private static final String PATH = "events/%s";
 
   private static final String KEY_AT = "at";
-  private static final String KEY_PUSH_HASH = "push_hash";
+  private static final String KEY_PUSH_ID = "push_id";
   private static final String KEY_DIMENSIONS = "dimensions";
 
   public static ParseRESTAnalyticsCommand trackAppOpenedCommand(
-      String pushHash, String sessionToken) {
-    return trackEventCommand(EVENT_APP_OPENED, pushHash, null, sessionToken);
+      String pushId, String sessionToken) {
+    return trackEventCommand(EVENT_APP_OPENED, pushId, null, sessionToken);
   }
 
   public static ParseRESTAnalyticsCommand trackEventCommand(
@@ -43,13 +43,13 @@ import java.util.Map;
   }
 
   /* package */ static ParseRESTAnalyticsCommand trackEventCommand(
-      String eventName, String pushHash, Map<String, String> dimensions, String sessionToken) {
+      String eventName, String pushId, Map<String, String> dimensions, String sessionToken) {
     String httpPath = String.format(PATH, Uri.encode(eventName));
     JSONObject parameters = new JSONObject();
     try {
       parameters.put(KEY_AT, NoObjectsEncoder.get().encode(new Date()));
-      if (pushHash != null) {
-        parameters.put(KEY_PUSH_HASH, pushHash);
+      if (pushId != null) {
+        parameters.put(KEY_PUSH_ID, pushId);
       }
       if (dimensions != null) {
         parameters.put(KEY_DIMENSIONS, NoObjectsEncoder.get().encode(dimensions));

--- a/Parse/src/test/java/com/parse/ParseAnalyticsControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParseAnalyticsControllerTest.java
@@ -105,7 +105,7 @@ public class ParseAnalyticsControllerTest {
 
     // Execute
     ParseAnalyticsController controller = new ParseAnalyticsController(queue);
-    ParseTaskUtils.wait(controller.trackAppOpenedInBackground("pushHash", "sessionToken"));
+    ParseTaskUtils.wait(controller.trackAppOpenedInBackground("pushId", "sessionToken"));
 
     // Verify eventuallyQueue.enqueueEventuallyAsync
     ArgumentCaptor<ParseRESTCommand> command = ArgumentCaptor.forClass(ParseRESTCommand.class);
@@ -120,7 +120,7 @@ public class ParseAnalyticsControllerTest {
     assertTrue(command.getValue() instanceof ParseRESTAnalyticsCommand);
     assertTrue(command.getValue().httpPath.contains(ParseRESTAnalyticsCommand.EVENT_APP_OPENED));
     assertEquals("sessionToken", command.getValue().getSessionToken());
-    assertEquals("pushHash", command.getValue().jsonParameters.get("push_hash"));
+    assertEquals("pushId", command.getValue().jsonParameters.get("push_id"));
   }
 
   //endregion

--- a/Parse/src/test/java/com/parse/ParseAnalyticsTest.java
+++ b/Parse/src/test/java/com/parse/ParseAnalyticsTest.java
@@ -243,7 +243,7 @@ public class ParseAnalyticsTest {
 
   @Test
   public void testGetPushHashFromIntentNullIntent() throws Exception {
-    String pushHash = ParseAnalytics.getPushHashFromIntent(null);
+    String pushHash = ParseAnalytics.getPushIdFromIntent(null);
 
     assertEquals(null, pushHash);
   }
@@ -257,7 +257,7 @@ public class ParseAnalyticsTest {
     bundle.putString("data_wrong_key", json.toString());
     intent.putExtras(bundle);
 
-    String pushHash = ParseAnalytics.getPushHashFromIntent(intent);
+    String pushHash = ParseAnalytics.getPushIdFromIntent(intent);
 
     assertEquals(null, pushHash);
   }
@@ -271,9 +271,9 @@ public class ParseAnalyticsTest {
     bundle.putString(ParsePushBroadcastReceiver.KEY_PUSH_DATA, json.toString());
     intent.putExtras(bundle);
 
-    String pushHash = ParseAnalytics.getPushHashFromIntent(intent);
+    String pushHash = ParseAnalytics.getPushIdFromIntent(intent);
 
-    assertEquals("", pushHash);
+    assertEquals(null, pushHash);
   }
 
   @Test
@@ -283,7 +283,7 @@ public class ParseAnalyticsTest {
     bundle.putString(ParsePushBroadcastReceiver.KEY_PUSH_DATA, "error_data");
     intent.putExtras(bundle);
 
-    String pushHash = ParseAnalytics.getPushHashFromIntent(intent);
+    String pushHash = ParseAnalytics.getPushIdFromIntent(intent);
 
     assertEquals(null, pushHash);
   }
@@ -292,18 +292,18 @@ public class ParseAnalyticsTest {
   public void testGetPushHashFromIntentNormalIntent() throws Exception {
     Intent intent = makeIntentWithParseData("test");
 
-    String pushHash = ParseAnalytics.getPushHashFromIntent(intent);
+    String pushHash = ParseAnalytics.getPushIdFromIntent(intent);
 
     assertEquals("test", pushHash);
   }
 
   //endregion
 
-  private Intent makeIntentWithParseData(String pushHash) throws JSONException {
+  private Intent makeIntentWithParseData(String pushId) throws JSONException {
     Intent intent = new Intent();
     Bundle bundle = new Bundle();
     JSONObject json = new JSONObject();
-    json.put("push_hash", pushHash);
+    json.put("push_id", pushId);
     bundle.putString(ParsePushBroadcastReceiver.KEY_PUSH_DATA, json.toString());
     intent.putExtras(bundle);
     return intent;

--- a/Parse/src/test/java/com/parse/ParseAnalyticsTest.java
+++ b/Parse/src/test/java/com/parse/ParseAnalyticsTest.java
@@ -299,12 +299,14 @@ public class ParseAnalyticsTest {
 
   //endregion
 
-  private Intent makeIntentWithParseData(String pushId) throws JSONException {
+  private Intent makeIntentWithParseData(String id) throws JSONException {
     Intent intent = new Intent();
     Bundle bundle = new Bundle();
-    JSONObject json = new JSONObject();
-    json.put("push_id", pushId);
-    bundle.putString(ParsePushBroadcastReceiver.KEY_PUSH_DATA, json.toString());
+    JSONObject pushData = new JSONObject();
+    JSONObject parseMetadata = new JSONObject();
+    parseMetadata.put("id", id);
+    pushData.put("parseMetadata", parseMetadata);
+    bundle.putString(ParsePushBroadcastReceiver.KEY_PUSH_DATA, pushData.toString());
     intent.putExtras(bundle);
     return intent;
   }

--- a/Parse/src/test/java/com/parse/ParseAnalyticsTest.java
+++ b/Parse/src/test/java/com/parse/ParseAnalyticsTest.java
@@ -204,11 +204,7 @@ public class ParseAnalyticsTest {
   public void testTrackAppOpenedInBackgroundDuplicatedIntent() throws Exception {
     Intent intent = makeIntentWithParseData("test");
     ParseTaskUtils.wait(ParseAnalytics.trackAppOpenedInBackground(intent));
-
-    verify(controller, times(1)).trackAppOpenedInBackground(eq("test"), isNull(String.class));
-
     ParseTaskUtils.wait(ParseAnalytics.trackAppOpenedInBackground(intent));
-
     verify(controller, times(1)).trackAppOpenedInBackground(eq("test"), isNull(String.class));
   }
 


### PR DESCRIPTION
`push_id` better uniquely identifies a push, as opposed to `push_hash`
which will determine two different pushes with the same content as the
same.