### PR TITLE
Fix #343: Add proguard consumer file

### DIFF
--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -25,6 +25,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName project.version
+        consumerProguardFiles 'release-proguard.pro'
     }
 
     lintOptions {

--- a/Parse/release-proguard.pro
+++ b/Parse/release-proguard.pro
@@ -16,3 +16,14 @@
 #   public *;
 #}
 
+# Keep source file names, line numbers, and Parse class/method names for easier debugging
+-keepattributes SourceFile,LineNumberTable
+-keepnames class com.parse.** { *; }
+
+# Required for Parse
+-keepattributes *Annotation*
+-keepattributes Signature
+-dontwarn android.net.SSLCertificateSocketFactory
+-dontwarn android.app.Notification
+-dontwarn com.squareup.**
+-dontwarn okio.**


### PR DESCRIPTION
The Android Gradle plugin allows to define ProGuard rules which get embedded in the AAR. These ProGuard rules are automatically applied when a consumer app sets minifyEnabled to true.