### PR TITLE
Don't override default SSL Socket Factory

### DIFF
--- a/Parse/src/main/java/com/parse/ParseURLConnectionHttpClient.java
+++ b/Parse/src/main/java/com/parse/ParseURLConnectionHttpClient.java
@@ -37,9 +37,6 @@ import javax.net.ssl.HttpsURLConnection;
 
   public ParseURLConnectionHttpClient(int socketOperationTimeout, SSLSessionCache sslSessionCache) {
     this.socketOperationTimeout = socketOperationTimeout;
-
-    HttpsURLConnection.setDefaultSSLSocketFactory(SSLCertificateSocketFactory.getDefault(
-        socketOperationTimeout, sslSessionCache));
   }
 
   @Override


### PR DESCRIPTION
This SSL Socket Factory is causing a javax.net.ssl.SSLPeerUnverifiedException exception when integrating an app with both Parse and Account Kit (https://developers.facebook.com/products/account-kit). Is there a reason why we're using the SSLCertificateSocketFactory? I think the default one should be fine.