### PR TITLE
Update for OkHttp3

### DIFF
--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -42,13 +42,13 @@ android {
 dependencies {
     compile 'com.parse.bolts:bolts-tasks:1.4.0'
 
-    provided 'com.squareup.okhttp3:okhttp:3.2.0'
+    provided 'com.squareup.okhttp3:okhttp:3.3.1'
     provided 'com.facebook.stetho:stetho:1.3.0'
 
     testCompile 'org.robolectric:robolectric:3.0'
     testCompile 'org.skyscreamer:jsonassert:1.2.3'
     testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.2.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.3.1'
 }
 
 android.libraryVariants.all { variant ->

--- a/Parse/src/test/java/com/parse/ParseOkHttpClientTest.java
+++ b/Parse/src/test/java/com/parse/ParseOkHttpClientTest.java
@@ -11,15 +11,6 @@ package com.parse;
 import com.parse.http.ParseHttpRequest;
 import com.parse.http.ParseHttpResponse;
 import com.parse.http.ParseNetworkInterceptor;
-import okhttp3.MediaType;
-import okhttp3.Protocol;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,6 +28,15 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 import okio.BufferedSource;
 
@@ -355,7 +355,7 @@ public class ParseOkHttpClientTest {
   // Generate a ParseHttpRequest sent to server
   private ParseHttpRequest generateClientRequest() throws Exception {
     Map<String, String> headers = new HashMap<>();
-    headers.put("requestKey", "requestValue");
+    headers.put("requestkey", "requestValue");
     JSONObject json = new JSONObject();
     json.put("key", "value");
     ParseHttpRequest parseRequest = new ParseHttpRequest.Builder()
@@ -372,7 +372,7 @@ public class ParseOkHttpClientTest {
   private void verifyClientRequest(ParseHttpRequest parseRequest) throws IOException {
     assertEquals(server.url("/").toString(), parseRequest.getUrl());
     assertEquals(ParseHttpRequest.Method.POST, parseRequest.getMethod());
-    assertEquals("requestValue", parseRequest.getHeader("requestKey"));
+    assertEquals("requestValue", parseRequest.getHeader("requestkey"));
     assertEquals("application/json", parseRequest.getBody().getContentType());
     JSONObject json = new JSONObject();
     try {


### PR DESCRIPTION
Changes to https://github.com/square/okhttp/commit/bab8943f2b5c8bc44a64067ada556aa62fcec3a7 has caused network interceptors to return headers all in lower case because a change in which the toMultimap() function.   This change appears to have been added to avoid duplicate headers being sent (https://github.com/square/okhttp/blob/bab8943f2b5c8bc44a64067ada556aa62fcec3a7/okhttp-tests/src/test/java/okhttp3/internal/http/HeadersTest.java#L298-L306).

The downside is that Parse/OkHttp network interceptors exhibit this behavior, but normal interceptors do not.   We call the toMultimap() routine that causes headers to be converted to lowercase on downstream requests (see https://github.com/ParsePlatform/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/ParseOkHttpClient.java#L187-L189)

I updated the tests to rely on lowercase headers to avoid the test falures.  I think the reasoning behind needing toMultiMap() is in case someone needs to rewrite the headers and you want to make sure you are overwriting the right one.  
