### PR TITLE
only add client key if non-null

### DIFF
--- a/Parse/src/main/java/com/parse/ParsePlugins.java
+++ b/Parse/src/main/java/com/parse/ParsePlugins.java
@@ -95,7 +95,6 @@ import java.io.IOException;
             ParseHttpRequest request = chain.getRequest();
             ParseHttpRequest.Builder builder = new ParseHttpRequest.Builder(request)
                 .addHeader(ParseRESTCommand.HEADER_APPLICATION_ID, applicationId)
-                .addHeader(ParseRESTCommand.HEADER_CLIENT_KEY, clientKey)
                 .addHeader(ParseRESTCommand.HEADER_CLIENT_VERSION, Parse.externalVersionName())
                 .addHeader(
                     ParseRESTCommand.HEADER_APP_BUILD_VERSION,
@@ -111,6 +110,10 @@ import java.io.IOException;
               // We can do this synchronously since the caller is already in a Task on the
               // NETWORK_EXECUTOR
               builder.addHeader(ParseRESTCommand.HEADER_INSTALLATION_ID, installationId().get());
+            }
+            // client key can be null with self-hosted Parse Server
+            if (clientKey != null) {
+              builder.addHeader(ParseRESTCommand.HEADER_CLIENT_KEY, clientKey);
             }
             return chain.proceed(builder.build());
           }


### PR DESCRIPTION
If you use OkHttp3 and a custom Parser server without a client key (e.g. `null` or no call to the Parse.Configuration.Builder), requests with OkHttp3 will fail due to a null value in the header: [Headers.java#L269](https://github.com/square/okhttp/blob/f491389d146014ac892417db15d495bcbc459728/okhttp/src/main/java/okhttp3/Headers.java#L269).
