### PR TITLE
fix bug in ParseOkHttpClient that can cause errors when saving ParseFile

### DIFF
--- a/Parse/src/main/java/com/parse/ParseOkHttpClient.java
+++ b/Parse/src/main/java/com/parse/ParseOkHttpClient.java
@@ -144,7 +144,7 @@ import okio.Okio;
     // Set Body
     ParseHttpBody parseBody = parseRequest.getBody();
     ParseOkHttpRequestBody okHttpRequestBody = null;
-    if(parseBody instanceof ParseByteArrayHttpBody) {
+    if(parseBody != null) {
       okHttpRequestBody = new ParseOkHttpRequestBody(parseBody);
     }
     switch (method) {


### PR DESCRIPTION
See #364 