### PR TITLE
Fix bug in ParseOkHttpClient

### DIFF
--- a/Parse/src/main/java/com/parse/ParseOkHttpClient.java
+++ b/Parse/src/main/java/com/parse/ParseOkHttpClient.java
@@ -117,7 +117,7 @@ import okio.Okio;
         okHttpRequestBuilder.get();
         break;
       case DELETE:
-        okHttpRequestBuilder.delete();
+        okHttpRequestBuilder.delete(null);
         break;
       case POST:
       case PUT:


### PR DESCRIPTION
ClassCastException happened while delete ParseObject
