### PR TITLE
Adding availableKeys to ParseObject.State

### DIFF
--- a/Parse/src/main/java/com/parse/NetworkQueryController.java
+++ b/Parse/src/main/java/com/parse/NetworkQueryController.java
@@ -134,8 +134,10 @@ import bolts.Task;
       if (resultClassName == null) {
         resultClassName = state.className();
       }
+      JSONArray safeKeys = new JSONArray(state.selectedKeys());
       for (int i = 0; i < results.length(); ++i) {
         JSONObject data = results.getJSONObject(i);
+        data.put("__safeKeys", safeKeys);
         T object = ParseObject.fromJSON(data, resultClassName, state.selectedKeys() == null);
         answer.add(object);
 

--- a/Parse/src/main/java/com/parse/NetworkQueryController.java
+++ b/Parse/src/main/java/com/parse/NetworkQueryController.java
@@ -134,11 +134,12 @@ import bolts.Task;
       if (resultClassName == null) {
         resultClassName = state.className();
       }
-      JSONArray safeKeys = new JSONArray(state.selectedKeys());
+      boolean isSubset = state.selectedKeys() != null;
+      JSONArray selectedKeys = isSubset ? new JSONArray(state.selectedKeys()) : null;
       for (int i = 0; i < results.length(); ++i) {
         JSONObject data = results.getJSONObject(i);
-        data.put(ParseObject.KEY_SAFEKEYS, safeKeys);
-        T object = ParseObject.fromJSON(data, resultClassName, state.selectedKeys() == null);
+        if (isSubset) data.put(ParseObject.KEY_SELECTED_KEYS, selectedKeys);
+        T object = ParseObject.fromJSON(data, resultClassName, !isSubset);
         answer.add(object);
 
         /*

--- a/Parse/src/main/java/com/parse/NetworkQueryController.java
+++ b/Parse/src/main/java/com/parse/NetworkQueryController.java
@@ -137,7 +137,7 @@ import bolts.Task;
       JSONArray safeKeys = new JSONArray(state.selectedKeys());
       for (int i = 0; i < results.length(); ++i) {
         JSONObject data = results.getJSONObject(i);
-        data.put("__safeKeys", safeKeys);
+        data.put(ParseObject.KEY_SAFEKEYS, safeKeys);
         T object = ParseObject.fromJSON(data, resultClassName, state.selectedKeys() == null);
         answer.add(object);
 

--- a/Parse/src/main/java/com/parse/NetworkQueryController.java
+++ b/Parse/src/main/java/com/parse/NetworkQueryController.java
@@ -134,12 +134,9 @@ import bolts.Task;
       if (resultClassName == null) {
         resultClassName = state.className();
       }
-      boolean isSubset = state.selectedKeys() != null;
-      JSONArray selectedKeys = isSubset ? new JSONArray(state.selectedKeys()) : null;
       for (int i = 0; i < results.length(); ++i) {
         JSONObject data = results.getJSONObject(i);
-        if (isSubset) data.put(ParseObject.KEY_SELECTED_KEYS, selectedKeys);
-        T object = ParseObject.fromJSON(data, resultClassName, !isSubset);
+        T object = ParseObject.fromJSON(data, resultClassName, ParseDecoder.get(), state.selectedKeys());
         answer.add(object);
 
         /*

--- a/Parse/src/main/java/com/parse/ParseDecoder.java
+++ b/Parse/src/main/java/com/parse/ParseDecoder.java
@@ -122,7 +122,7 @@ import org.json.JSONObject;
     }
 
     if (typeString.equals("Object")) {
-      return ParseObject.fromJSON(jsonObject, null, true, this);
+      return ParseObject.fromJSON(jsonObject, null, !jsonObject.has(ParseObject.KEY_SELECTED_KEYS), this);
     }
 
     if (typeString.equals("Relation")) {

--- a/Parse/src/main/java/com/parse/ParseDecoder.java
+++ b/Parse/src/main/java/com/parse/ParseDecoder.java
@@ -122,7 +122,7 @@ import org.json.JSONObject;
     }
 
     if (typeString.equals("Object")) {
-      return ParseObject.fromJSON(jsonObject, null, !jsonObject.has(ParseObject.KEY_SELECTED_KEYS), this);
+      return ParseObject.fromJSON(jsonObject, null, this);
     }
 
     if (typeString.equals("Relation")) {

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -64,6 +64,7 @@ public class ParseObject {
   */
   private static final String KEY_COMPLETE = "__complete";
   private static final String KEY_OPERATIONS = "__operations";
+  /* package */ static final String KEY_SAFEKEYS = "__safeKeys";
   /* package */ static final String KEY_IS_DELETING_EVENTUALLY = "__isDeletingEventually";
   // Because Grantland messed up naming this... We'll only try to read from this for backward
   // compat, but I think we can be safe to assume any deleteEventuallys from long ago are obsolete
@@ -175,6 +176,7 @@ public class ParseObject {
         updatedAt = -1;
         isComplete = false;
         serverData.clear();
+        safeKeys.clear();
         return self();
       }
 
@@ -254,7 +256,7 @@ public class ParseObject {
           : createdAt;
       serverData = Collections.unmodifiableMap(new HashMap<>(builder.serverData));
       isComplete = builder.isComplete;
-      safeKeys = builder.safeKeys;
+      safeKeys = new HashSet<>(builder.safeKeys);
     }
 
     @SuppressWarnings("unchecked")
@@ -939,7 +941,7 @@ public class ParseObject {
           builder.put(KEY_ACL, acl);
           continue;
         }
-        if (key.equals("__safeKeys")) {
+        if (key.equals(KEY_SAFEKEYS)) {
           JSONArray safeKeys = json.getJSONArray(key);
           if (safeKeys.length() > 0) {
             Collection<String> set = new HashSet<>();
@@ -1018,6 +1020,8 @@ public class ParseObject {
         // using the REST api and want to send data to Parse.
         json.put(KEY_COMPLETE, state.isComplete());
         json.put(KEY_IS_DELETING_EVENTUALLY, isDeletingEventually);
+        JSONArray safekeys = new JSONArray(state.safeKeys());
+        json.put(KEY_SAFEKEYS, safekeys);
 
         // Operation Set Queue
         JSONArray operations = new JSONArray();

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -946,7 +946,8 @@ public class ParseObject {
             for (int i = 0; i < safeKeys.length(); i++) {
               // Don't add nested keys.
               String safeKey = safeKeys.getString(i);
-              if (!safeKey.contains(".")) set.add(safeKey);
+              if (safeKey.contains(".")) safeKey = safeKey.split(".")[0];
+              set.add(safeKey);
             }
             builder.safeKeys(set);
           }

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -64,6 +64,8 @@ public class ParseObject {
   */
   private static final String KEY_COMPLETE = "__complete";
   private static final String KEY_OPERATIONS = "__operations";
+  // Array of keys selected when querying for the object. Helps decoding nested {@code ParseObject}s
+  // correctly, and helps constructing the {@code State.safeKeys()} set.
   private static final String KEY_SELECTED_KEYS = "__selectedKeys";
   /* package */ static final String KEY_IS_DELETING_EVENTUALLY = "__isDeletingEventually";
   // Because Grantland messed up naming this... We'll only try to read from this for backward
@@ -293,6 +295,10 @@ public class ParseObject {
       return serverData.keySet();
     }
 
+    // Extra keys that are undefined for this object, but that can be accessed without throwing.
+    // These come e.g. from ParseQuery.selectKeys(). Selected keys must be available to get()
+    // methods even if undefined, for consistency with complete objects.
+    // For a complete object, this set is empty.
     public Set<String> safeKeys() {
       return safeKeys;
     }
@@ -612,8 +618,7 @@ public class ParseObject {
   /* package */ static <T extends ParseObject> T fromJSON(JSONObject json, String defaultClassName,
                                                           ParseDecoder decoder,
                                                           Set<String> selectedKeys) {
-    boolean complete = selectedKeys == null || selectedKeys.isEmpty();
-    if (!complete) {
+    if (selectedKeys != null && !selectedKeys.isEmpty()) {
       JSONArray keys = new JSONArray(selectedKeys);
       try {
         json.put(KEY_SELECTED_KEYS, keys);

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -620,6 +620,7 @@ public class ParseObject {
    * @param isComplete
    *          {@code true} if this is all of the data on the server for the object.
    * @param decoder
+   *          Delegate for knowing how to decode the values in the JSON.
    */
   /* package */ static <T extends ParseObject> T fromJSON(JSONObject json, String defaultClassName,
                                                           boolean isComplete, ParseDecoder decoder) {
@@ -946,7 +947,7 @@ public class ParseObject {
             for (int i = 0; i < safeKeys.length(); i++) {
               // Don't add nested keys.
               String safeKey = safeKeys.getString(i);
-              if (safeKey.contains(".")) safeKey = safeKey.split(".")[0];
+              if (safeKey.contains(".")) safeKey = safeKey.split("\\.")[0];
               set.add(safeKey);
             }
             builder.safeKeys(set);
@@ -961,7 +962,7 @@ public class ParseObject {
           JSONArray nestedKeys = new JSONArray();
           for (int i = 0; i < selectedKeys.length(); i++) {
             String nestedKey = selectedKeys.getString(i);
-            if (nestedKey.startsWith(key+".")) nestedKeys.put(nestedKey.substring(key.length()+1));
+            if (nestedKey.startsWith(key + ".")) nestedKeys.put(nestedKey.substring(key.length() + 1));
           }
           if (nestedKeys.length() > 0) {
             ((JSONObject) value).put(KEY_SELECTED_KEYS, nestedKeys);

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -198,6 +198,7 @@ public class ParseObject {
         for (String key : other.keySet()) {
           put(key, other.get(key));
         }
+        safeKeys(other.safeKeys());
         return self();
       }
 
@@ -297,7 +298,7 @@ public class ParseObject {
     public String toString() {
       return String.format(Locale.US, "%s@%s[" +
               "className=%s, objectId=%s, createdAt=%d, updatedAt=%d, isComplete=%s, " +
-              "serverData=%s]",
+              "serverData=%s, safeKeys=%s]",
           getClass().getName(),
           Integer.toHexString(hashCode()),
           className,
@@ -305,7 +306,8 @@ public class ParseObject {
           createdAt,
           updatedAt,
           isComplete,
-          serverData);
+          serverData,
+          safeKeys);
     }
   }
 

--- a/Parse/src/test/java/com/parse/ParseDecoderTest.java
+++ b/Parse/src/test/java/com/parse/ParseDecoderTest.java
@@ -240,6 +240,34 @@ public class ParseDecoderTest {
   }
 
   @Test
+  public void testCompletenessOfIncludedParseObject() throws JSONException {
+    JSONObject json = new JSONObject();
+    json.put("__type", "Object");
+    json.put("className", "GameScore");
+    json.put("createdAt", "2015-06-22T21:23:41.733Z");
+    json.put("objectId", "TT1ZskATqS");
+    json.put("updatedAt", "2015-06-22T22:06:18.104Z");
+
+    JSONObject child = new JSONObject();
+    child.put("__type", "Object");
+    child.put("className", "GameScore");
+    child.put("createdAt", "2015-06-22T21:23:41.733Z");
+    child.put("objectId", "TT1ZskATqR");
+    child.put("updatedAt", "2015-06-22T22:06:18.104Z");
+    child.put("bar", "child bar");
+
+    JSONArray arr = new JSONArray("[\"foo.bar\"]");
+    json.put("foo", child);
+    json.put("__selectedKeys", arr);
+    ParseObject parentObject = (ParseObject) ParseDecoder.get().decode(json);
+    assertFalse(parentObject.isDataAvailable());
+    assertTrue(parentObject.isDataAvailable("foo"));
+    ParseObject childObject = parentObject.getParseObject("foo");
+    assertFalse(childObject.isDataAvailable());
+    assertTrue(childObject.isDataAvailable("bar"));
+  }
+
+  @Test
   public void testRelation() throws JSONException {
     JSONObject json = new JSONObject();
     json.put("__type", "Relation");

--- a/Parse/src/test/java/com/parse/ParseDecoderTest.java
+++ b/Parse/src/test/java/com/parse/ParseDecoderTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 // For android.util.Base64
 @RunWith(RobolectricTestRunner.class)
@@ -196,6 +197,46 @@ public class ParseDecoderTest {
     json.put("updatedAt", "2015-06-22T22:06:18.104Z");
     ParseObject parseObject = (ParseObject) ParseDecoder.get().decode(json);
     assertNotNull(parseObject);
+  }
+
+  @Test
+  public void testIncludedParseObject() throws JSONException {
+    JSONObject json = new JSONObject();
+    json.put("__type", "Object");
+    json.put("className", "GameScore");
+    json.put("createdAt", "2015-06-22T21:23:41.733Z");
+    json.put("objectId", "TT1ZskATqS");
+    json.put("updatedAt", "2015-06-22T22:06:18.104Z");
+
+    JSONObject child = new JSONObject();
+    child.put("__type", "Object");
+    child.put("className", "GameScore");
+    child.put("createdAt", "2015-06-22T21:23:41.733Z");
+    child.put("objectId", "TT1ZskATqR");
+    child.put("updatedAt", "2015-06-22T22:06:18.104Z");
+
+    json.put("child", child);
+    ParseObject parseObject = (ParseObject) ParseDecoder.get().decode(json);
+    assertNotNull(parseObject.getParseObject("child"));
+  }
+
+  @Test
+  public void testCompleteness() throws JSONException {
+    JSONObject json = new JSONObject();
+    json.put("__type", "Object");
+    json.put("className", "GameScore");
+    json.put("createdAt", "2015-06-22T21:23:41.733Z");
+    json.put("objectId", "TT1ZskATqS");
+    json.put("updatedAt", "2015-06-22T22:06:18.104Z");
+    json.put("foo", "foo");
+    json.put("bar", "bar");
+    ParseObject parseObject = (ParseObject) ParseDecoder.get().decode(json);
+    assertTrue(parseObject.isDataAvailable());
+
+    JSONArray arr = new JSONArray("[\"foo\"]");
+    json.put("__selectedKeys", arr);
+    parseObject = (ParseObject) ParseDecoder.get().decode(json);
+    assertFalse(parseObject.isDataAvailable());
   }
 
   @Test

--- a/Parse/src/test/java/com/parse/ParseObjectStateTest.java
+++ b/Parse/src/test/java/com/parse/ParseObjectStateTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.contains;
 
 public class ParseObjectStateTest {
 
@@ -31,7 +30,7 @@ public class ParseObjectStateTest {
     assertEquals(-1, state.updatedAt());
     assertFalse(state.isComplete());
     assertTrue(state.keySet().isEmpty());
-    assertTrue(state.safeKeys().isEmpty());
+    assertTrue(state.availableKeys().isEmpty());
   }
 
   @Test
@@ -64,7 +63,7 @@ public class ParseObjectStateTest {
         .isComplete(true)
         .put("foo", "bar")
         .put("baz", "qux")
-        .safeKeys(Arrays.asList("safe", "keys"))
+        .availableKeys(Arrays.asList("safe", "keys"))
         .build();
     ParseObject.State copy = new ParseObject.State.Builder(state).build();
     assertEquals(state.className(), copy.className());
@@ -75,9 +74,9 @@ public class ParseObjectStateTest {
     assertEquals(state.keySet().size(), copy.keySet().size());
     assertEquals(state.get("foo"), copy.get("foo"));
     assertEquals(state.get("baz"), copy.get("baz"));
-    assertEquals(state.safeKeys().size(), copy.safeKeys().size());
-    assertTrue(state.safeKeys().containsAll(copy.safeKeys()));
-    assertTrue(copy.safeKeys().containsAll(state.safeKeys()));
+    assertEquals(state.availableKeys().size(), copy.availableKeys().size());
+    assertTrue(state.availableKeys().containsAll(copy.availableKeys()));
+    assertTrue(copy.availableKeys().containsAll(state.availableKeys()));
   }
 
   @Test
@@ -127,6 +126,6 @@ public class ParseObjectStateTest {
     assertTrue(string.contains("updatedAt"));
     assertTrue(string.contains("isComplete"));
     assertTrue(string.contains("serverData"));
-    assertTrue(string.contains("safeKeys"));
+    assertTrue(string.contains("availableKeys"));
   }
 }

--- a/Parse/src/test/java/com/parse/ParseObjectStateTest.java
+++ b/Parse/src/test/java/com/parse/ParseObjectStateTest.java
@@ -10,6 +10,7 @@ package com.parse;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
@@ -30,6 +31,7 @@ public class ParseObjectStateTest {
     assertEquals(-1, state.updatedAt());
     assertFalse(state.isComplete());
     assertTrue(state.keySet().isEmpty());
+    assertTrue(state.safeKeys().isEmpty());
   }
 
   @Test
@@ -62,6 +64,7 @@ public class ParseObjectStateTest {
         .isComplete(true)
         .put("foo", "bar")
         .put("baz", "qux")
+        .safeKeys(Arrays.asList("safe", "keys"))
         .build();
     ParseObject.State copy = new ParseObject.State.Builder(state).build();
     assertEquals(state.className(), copy.className());
@@ -72,6 +75,9 @@ public class ParseObjectStateTest {
     assertEquals(state.keySet().size(), copy.keySet().size());
     assertEquals(state.get("foo"), copy.get("foo"));
     assertEquals(state.get("baz"), copy.get("baz"));
+    assertEquals(state.safeKeys().size(), copy.safeKeys().size());
+    assertTrue(state.safeKeys().containsAll(copy.safeKeys()));
+    assertTrue(copy.safeKeys().containsAll(state.safeKeys()));
   }
 
   @Test
@@ -121,5 +127,6 @@ public class ParseObjectStateTest {
     assertTrue(string.contains("updatedAt"));
     assertTrue(string.contains("isComplete"));
     assertTrue(string.contains("serverData"));
+    assertTrue(string.contains("safeKeys"));
   }
 }

--- a/Parse/src/test/java/com/parse/ParseObjectTest.java
+++ b/Parse/src/test/java/com/parse/ParseObjectTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -237,7 +238,16 @@ public class ParseObjectTest {
     ParseObject.State state = mock(ParseObject.State.class);
     when(state.className()).thenReturn("TestObject");
     when(state.isComplete()).thenReturn(false);
+    ParseObject object = ParseObject.from(state);
+    object.get("foo");
+  }
 
+  @Test
+  public void testGetAvailableIfKeySafe() {
+    ParseObject.State state = mock(ParseObject.State.class);
+    when(state.className()).thenReturn("TestObject");
+    when(state.isComplete()).thenReturn(false);
+    when(state.safeKeys()).thenReturn(new HashSet<>(Arrays.asList("foo")));
     ParseObject object = ParseObject.from(state);
     object.get("foo");
   }

--- a/Parse/src/test/java/com/parse/ParseObjectTest.java
+++ b/Parse/src/test/java/com/parse/ParseObjectTest.java
@@ -243,11 +243,11 @@ public class ParseObjectTest {
   }
 
   @Test
-  public void testGetAvailableIfKeySafe() {
+  public void testGetAvailableIfKeyAvailable() {
     ParseObject.State state = mock(ParseObject.State.class);
     when(state.className()).thenReturn("TestObject");
     when(state.isComplete()).thenReturn(false);
-    when(state.safeKeys()).thenReturn(new HashSet<>(Arrays.asList("foo")));
+    when(state.availableKeys()).thenReturn(new HashSet<>(Arrays.asList("foo")));
     ParseObject object = ParseObject.from(state);
     object.get("foo");
   }


### PR DESCRIPTION
- Adds a availableKeys property to ParseObject.state that includes keys that can be safely accessed. Fixes #595 so now there is consistency between complete and non-complete objects.

   While it seems to work on my machine, I have no deep understanding of the library. Nothing should be broken though. 

- Exposing `ParseObject.isDataAvailable(String key)`. Right now there are:

    -  `ParseObject.has(String key)`: alias to containsKey(key)
    - `ParseObject.containsKey(String key):` true if the server sent out data for this key

    Neither of these can be used to know if `ParseObject.get*` methods can be called safely. In some cases `has(key)` returns false but `get(key)` can be called without throwing. In some others `has(key)` returns false and `get(key)` will throw.

    This PR exposes `isDataAvailable(String key)` for partially fetched objects. When false, `get*` methods will throw. So with the PR:

   - `ParseObject.containsKey(String key)`: we have some data for this key from the server.
   - `ParseObject.isDataAvailable()`: the object is complete, all getters can be called.
   - `ParseObject.isDataAvailable(String key)`: the object might not be complete, but you can call get(key) safely.
    
  This makes sense to me.

- Fixes #597 adding support for nested selected keys. If there are some, nested objects will not be considered complete.