### PR TITLE
Support for setting up Server Url in the Manifest

### DIFF
--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -51,7 +51,7 @@ public class Parse {
       private Context context;
       private String applicationId;
       private String clientKey;
-      private String server = "https://api.parse.com/1/";
+      private String server = null;
       private boolean localDataStoreEnabled;
       private List<ParseNetworkInterceptor> interceptors;
 
@@ -98,6 +98,7 @@ public class Parse {
           Context applicationContext = context.getApplicationContext();
           Bundle metaData = ManifestInfo.getApplicationMetadata(applicationContext);
           if (metaData != null) {
+            server(metaData.getString(PARSE_SERVER_URL));
             applicationId = metaData.getString(PARSE_APPLICATION_ID);
             clientKey = metaData.getString(PARSE_CLIENT_KEY);
           }
@@ -145,7 +146,7 @@ public class Parse {
 
         // Add an extra trailing slash so that Parse REST commands include
         // the path as part of the server URL (i.e. http://api.myhost.com/parse)
-        if (server.endsWith("/") == false) {
+        if (server != null && !server.endsWith("/")) {
           server = server + "/";
         }
 
@@ -223,6 +224,7 @@ public class Parse {
     }
   }
 
+  private static final String PARSE_SERVER_URL = "com.parse.SERVER_URL";
   private static final String PARSE_APPLICATION_ID = "com.parse.APPLICATION_ID";
   private static final String PARSE_CLIENT_KEY = "com.parse.CLIENT_KEY";
 
@@ -322,18 +324,18 @@ public class Parse {
    */
   public static void initialize(Context context) {
     Configuration.Builder builder = new Configuration.Builder(context);
-    if (builder.applicationId == null) {
+    if (builder.server == null) {
+      throw new RuntimeException("ServerUrl not defined. " +
+          "You must provide ServerUrl in AndroidManifest.xml.\n" +
+          "<meta-data\n" +
+          "    android:name=\"com.parse.SERVER_URL\"\n" +
+          "    android:value=\"<Your Server Url>\" />");
+    } if (builder.applicationId == null) {
       throw new RuntimeException("ApplicationId not defined. " +
         "You must provide ApplicationId in AndroidManifest.xml.\n" +
         "<meta-data\n" +
         "    android:name=\"com.parse.APPLICATION_ID\"\n" +
         "    android:value=\"<Your Application Id>\" />");
-    } if (builder.clientKey == null) {
-      throw new RuntimeException("ClientKey not defined. " +
-        "You must provide ClientKey in AndroidManifest.xml.\n" +
-        "<meta-data\n" +
-        "    android:name=\"com.parse.CLIENT_KEY\"\n" +
-        "    android:value=\"<Your Client Key>\" />");
     }
     initialize(builder.setNetworkInterceptors(interceptors)
         .setLocalDatastoreEnabled(isLocalDatastoreEnabled)

--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -62,7 +62,7 @@ public class Parse {
        * initialization.
        *
        * <p/>
-       * You may define {@code com.parse.APPLICATION_ID} and {@code com.parse.CLIENT_KEY}
+       * You may define {@code com.parse.SERVER_URL}, {@code com.parse.APPLICATION_ID} and (optional) {@code com.parse.CLIENT_KEY}
        * {@code meta-data} in your {@code AndroidManifest.xml}:
        * <pre>
        * &lt;manifest ...&gt;
@@ -70,6 +70,9 @@ public class Parse {
        * ...
        *
        *   &lt;application ...&gt;
+       *     &lt;meta-data
+       *       android:name="com.parse.SERVER_URL"
+       *       android:value="@string/parse_server_url" /&gt;
        *     &lt;meta-data
        *       android:name="com.parse.APPLICATION_ID"
        *       android:value="@string/parse_app_id" /&gt;
@@ -84,7 +87,7 @@ public class Parse {
        * </pre>
        * <p/>
        *
-       * This will cause the values for {@code applicationId} and {@code clientKey} to be set to
+       * This will cause the values for {@code server}, {@code applicationId} and {@code clientKey} to be set to
        * those defined in your manifest.
        *
        * @param context The active {@link Context} for your application. Cannot be null.

--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -51,7 +51,7 @@ public class Parse {
       private Context context;
       private String applicationId;
       private String clientKey;
-      private String server = null;
+      private String server;
       private boolean localDataStoreEnabled;
       private List<ParseNetworkInterceptor> interceptors;
 

--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -289,7 +289,7 @@ public class Parse {
   /**
    * Authenticates this client as belonging to your application.
    * <p/>
-   * You must define {@code com.parse.APPLICATION_ID} and {@code com.parse.CLIENT_KEY}
+   * You may define {@code com.parse.SERVER_URL}, {@code com.parse.APPLICATION_ID} and (optional) {@code com.parse.CLIENT_KEY}
    * {@code meta-data} in your {@code AndroidManifest.xml}:
    * <pre>
    * &lt;manifest ...&gt;
@@ -297,6 +297,9 @@ public class Parse {
    * ...
    *
    *   &lt;application ...&gt;
+   *     &lt;meta-data
+   *       android:name="com.parse.SERVER_URL"
+   *       android:value="@string/parse_server_url" /&gt;
    *     &lt;meta-data
    *       android:name="com.parse.APPLICATION_ID"
    *       android:value="@string/parse_app_id" /&gt;

--- a/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
+++ b/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, packageName = "com.parse.example")
+@Config(constants = BuildConfig.class)
 public class ParseClientConfigurationTest {
 
   private final String serverUrl = "http://example.com/parse";

--- a/ParseStarterProject/src/main/AndroidManifest.xml
+++ b/ParseStarterProject/src/main/AndroidManifest.xml
@@ -20,6 +20,9 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <meta-data
+            android:name="com.parse.SERVER_URL"
+            android:value="@string/parse_server_url" />
+        <meta-data
             android:name="com.parse.APPLICATION_ID"
             android:value="@string/parse_app_id" />
         <meta-data

--- a/ParseStarterProject/src/main/res/values/strings.xml
+++ b/ParseStarterProject/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
   ~ of patent rights can be found in the PATENTS file in the same directory.
   -->
 <resources>
+    <string name="parse_server_url">YOUR_SERVER_URL</string>
     <string name="parse_app_id">YOUR_APPLICATION_ID</string>
     <string name="parse_client_key">YOUR_CLIENT_KEY</string>
 


### PR DESCRIPTION
Since `parse.com` has stopped, the Manifest for `Parser Server` setting up is not appropriate now. 
This PR add a support for setting up ServerUrl in the Manifest. Also updates the `ParseStarterProject`.