### PR TITLE
fix typo

### DIFF
--- a/Parse/src/main/java/com/parse/ParseInstallation.java
+++ b/Parse/src/main/java/com/parse/ParseInstallation.java
@@ -150,7 +150,7 @@ public class ParseInstallation extends ParseObject {
                 && ((ParseException) task.getError()).getCode() == ParseException.OBJECT_NOT_FOUND) {
           synchronized (mutex) {
             setObjectId(null);
-            markAllFieldDirty();
+            markAllFieldsDirty();
             return ParseInstallation.super.saveAsync(sessionToken, toAwait);
           }
         }

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -2881,7 +2881,7 @@ public class ParseObject {
     }
   }
 
-  /* package */ void markAllFieldDirty() {
+  /* package */ void markAllFieldsDirty() {
     synchronized (mutex) {
       estimatedData.clear();
       for (String key : state.keySet()) {


### PR DESCRIPTION
rename the function
`markAllFieldDirty` -> `markAllFieldsDirty` (should be plural)