### PR TITLE
Minor optimization in ParseObject.markAllFieldsDirty()

### DIFF
--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -2883,7 +2883,6 @@ public class ParseObject {
 
   /* package */ void markAllFieldsDirty() {
     synchronized (mutex) {
-      estimatedData.clear();
       for (String key : state.keySet()) {
         performPut(key, state.get(key));
       }


### PR DESCRIPTION
Continuation of the PR #579. 
No needs to clear the `estimatedData` before reset it to the original state.